### PR TITLE
Separate cooling cfl and reorder floors

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -51,6 +51,26 @@ Parameter: `reconstruction` (string)
 
 Note, `ppm` and `wenoz` need at least three ghost zones (`parthenon/mesh/num_ghost`).
 
+#### Optically thin cooling
+
+Optically thin cooling is enabled through the `cooling` block in the input file.
+A possible block might look like:
+
+```
+<cooling>
+enable_cooling = tabular           # To disable, set to `none`
+table_filename = schure.cooling    # Path to the cooling table (in a text file)
+log_temp_col = 0                   # Column in the file that contains the log10 temperatures
+log_lambda_col = 1                 # Column in the file that contains the cooling rates
+lambda_units_cgs = 1               # Conversion factor of the cooling rate relative to CGS units
+
+integrator = townsend              # Other possible options are `rk12` and `rk45` for error bound subcycling
+#max_iter = 100                    # Max number of iteration for subcycling. Unsued for Townsend integrator
+cfl = 0.1                          # Restrict global timestep to `cfl*e / dedt`, i.e., some fraction of change per cycle in the specific internal energy (i.e., temperature)
+d_log_temp_tol = 1e-8              # Tolerance in cooling table between subsequent entries. Both subcycling integrators and cfl restriction rely on a table lookup that assumes equally spaced (in log space) temperature values.
+#d_e_tol = 1e-8                    # Tolerance for the relative error in the change of internal energy for the error bound subcyling integrators (rk12 and rk45). Unused for Townsend integrator.
+```
+
 #### Diffusive processes
 
 ##### Anisotropic thermal conduction (required MHD)

--- a/docs/input.md
+++ b/docs/input.md
@@ -198,7 +198,6 @@ d_log_temp_tol = 1e-8              # Tolerance in cooling table between subseque
 ```
 
 *Note* several special cases for handling the lower end of the cooling table/low temperatures:
-- cooling is turned off once the temperature reaches the lower end of the cooling table
-- the explicit, global temperature floor `<hydro/Tfloor>` takes precedence over the lower end of the cooling table
-- in the cooling function only the temperature floor `<hydro/Tfloor>` (will be used
-(not the pressure floor, if present).
+- Cooling is turned off once the temperature reaches the lower end of the cooling table. Within the cooling function, gas does not cool past the cooling table.
+- If the global temperature floor `<hydro/Tfloor>` is higher than the lower end of the cooling table, then the global temperature floor takes precedence.
+- The pressure floor if present is not considered in the cooling function, only the temperature floor `<hydro/Tfloor>`

--- a/src/eos/adiabatic_glmmhd.cpp
+++ b/src/eos/adiabatic_glmmhd.cpp
@@ -104,16 +104,20 @@ void AdiabaticGLMMHDEOS::ConservedToPrimitive(MeshData<Real> *md) const {
             w_p > 0.0 || pressure_floor_ > 0.0 || e_floor_ > 0.0,
             "Got negative pressure. Consider enabling first-order flux "
             "correction or setting a reasonble pressure or temperature floor.");
-        // Temperature floor (if present) takes precedence over pressure floor
-        if (e_floor_ > 0.0) {
-          // apply temperature floor, correct total energy
-          const Real eff_pressure_floor = gm1 * u_d * e_floor_;
-          u_e = (w_p > eff_pressure_floor) ? u_e : ((u_d * e_floor_) + e_k + e_B);
-          w_p = (w_p > eff_pressure_floor) ? w_p : eff_pressure_floor;
-        } else {
+
+        // Pressure floor (if present) takes precedence over temperature floor
+        if ((pressure_floor_ > 0.0) && (w_p < pressure_floor_)) {
           // apply pressure floor, correct total energy
-          u_e = (w_p > pressure_floor_) ? u_e : ((pressure_floor_ / gm1) + e_k + e_B);
-          w_p = (w_p > pressure_floor_) ? w_p : pressure_floor_;
+          u_e = (pressure_floor_ / gm1) + e_k + e_B;
+          w_p = pressure_floor_;
+        }
+
+        // temperature (internal energy) based pressure floor
+        const Real eff_pressure_floor = gm1 * u_d * e_floor_;
+        if (w_p < eff_pressure_floor) {
+          // apply temperature floor, correct total energy
+          u_e = (u_d * e_floor_) + e_k + e_B;
+          w_p = eff_pressure_floor;
         }
 
         // Convert passive scalars

--- a/src/eos/adiabatic_hydro.cpp
+++ b/src/eos/adiabatic_hydro.cpp
@@ -87,16 +87,19 @@ void AdiabaticHydroEOS::ConservedToPrimitive(MeshData<Real> *md) const {
             "Got negative pressure. Consider enabling first-order flux "
             "correction or setting a reasonble pressure or temperature floor.");
 
-        // Temperature floor (if present) takes precedence over pressure floor
-        if (e_floor_ > 0.0) {
-          // apply temperature floor, correct total energy
-          const Real eff_pressure_floor = gm1 * u_d * e_floor_;
-          u_e = (w_p > eff_pressure_floor) ? u_e : ((u_d * e_floor_) + e_k);
-          w_p = (w_p > eff_pressure_floor) ? w_p : eff_pressure_floor;
-        } else {
+        // Pressure floor (if present) takes precedence over temperature floor
+        if ((pressure_floor_ > 0.0) && (w_p < pressure_floor_)) {
           // apply pressure floor, correct total energy
-          u_e = (w_p > pressure_floor_) ? u_e : ((pressure_floor_ / gm1) + e_k);
-          w_p = (w_p > pressure_floor_) ? w_p : pressure_floor_;
+          u_e = (pressure_floor_ / gm1) + e_k;
+          w_p = pressure_floor_;
+        }
+
+        // temperature (internal energy) based pressure floor
+        const Real eff_pressure_floor = gm1 * u_d * e_floor_;
+        if (w_p < eff_pressure_floor) {
+          // apply temperature floor, correct total energy
+          u_e = (u_d * e_floor_) + e_k;
+          w_p = eff_pressure_floor;
         }
 
         // Convert passive scalars

--- a/src/eos/eos.hpp
+++ b/src/eos/eos.hpp
@@ -43,6 +43,7 @@ class EquationOfState {
   KOKKOS_INLINE_FUNCTION
   Real GetDensityFloor() const { return density_floor_; }
 
+  // returns *specific* internal energy
   KOKKOS_INLINE_FUNCTION
   Real GetInternalEFloor() const { return internal_e_floor_; }
 

--- a/src/hydro/srcterms/tabular_cooling.cpp
+++ b/src/hydro/srcterms/tabular_cooling.cpp
@@ -301,7 +301,7 @@ void TabularCooling::SubcyclingFixedIntSrcTerm(MeshData<Real> *md, const Real dt
   //Determine the cooling floor, whichever is higher of the cooling table floor
   //or fluid solver floor
   const auto temp_cool_floor = std::pow(10.0, log_temp_start_); // low end of cool table
-  const Real temp_floor =  (T_floor_ > temp_cool_floor) T_floor ? temp_cool_floor;
+  const Real temp_floor =  (T_floor_ > temp_cool_floor)? T_floor_ : temp_cool_floor;
 
   const Real internal_e_floor = temp_floor / mu_m_u_gm1_by_k_B; // specific internal en.
 
@@ -474,7 +474,7 @@ void TabularCooling::SubcyclingFixedIntSrcTerm(MeshData<Real> *md, const Real dt
         // ConservedToPrim conversion, but keeping it for now (better safe than sorry).
         prim(IPR, k, j, i) = rho * internal_e * gm1;
       });
-a
+}
 
 void TabularCooling::TownsendSrcTerm(parthenon::MeshData<parthenon::Real> *md,
                                      const parthenon::Real dt_) const {
@@ -611,7 +611,7 @@ Real TabularCooling::EstimateTimeStep(MeshData<Real> *md) const {
   //Determine the cooling floor, whichever is higher of the cooling table floor
   //or fluid solver floor
   const auto temp_cool_floor = std::pow(10.0, log_temp_start_); // low end of cool table
-  const Real temp_floor =  (T_floor_ > temp_cool_floor) T_floor ? temp_cool_floor;
+  const Real temp_floor =  (T_floor_ > temp_cool_floor)? T_floor_ : temp_cool_floor;
 
   const Real internal_e_floor = temp_floor / mu_m_u_gm1_by_k_B; // specific internal en.
 

--- a/src/hydro/srcterms/tabular_cooling.cpp
+++ b/src/hydro/srcterms/tabular_cooling.cpp
@@ -297,7 +297,13 @@ void TabularCooling::SubcyclingFixedIntSrcTerm(MeshData<Real> *md, const Real dt
   const Real min_sub_dt = dt / max_iter;
 
   const Real d_e_tol = d_e_tol_;
-  const Real internal_e_floor = T_floor_ / mu_m_u_gm1_by_k_B; // specific internal en.
+
+  //Determine the cooling floor, whichever is higher of the cooling table floor
+  //or fluid solver floor
+  const auto temp_cool_floor = std::pow(10.0, log_temp_start_); // low end of cool table
+  const Real temp_floor =  (T_floor_ > temp_cool_floor) T_floor ? temp_cool_floor;
+
+  const Real internal_e_floor = temp_floor / mu_m_u_gm1_by_k_B; // specific internal en.
 
   // Grab some necessary variables
   const auto &prim_pack = md->PackVariables(std::vector<std::string>{"prim"});
@@ -347,7 +353,7 @@ void TabularCooling::SubcyclingFixedIntSrcTerm(MeshData<Real> *md, const Real dt
         // Check if cooling is actually happening, e.g., when T below T_cool_min or if
         // temperature is already below floor.
         const Real dedt_initial = DeDt_wrapper(0.0, internal_e_initial, dedt_valid);
-        if (dedt_initial == 0.0 || internal_e_initial < internal_e_floor) {
+        if (dedt_initial == 0.0 || internal_e_initial <= internal_e_floor) {
           return;
         }
 
@@ -468,7 +474,7 @@ void TabularCooling::SubcyclingFixedIntSrcTerm(MeshData<Real> *md, const Real dt
         // ConservedToPrim conversion, but keeping it for now (better safe than sorry).
         prim(IPR, k, j, i) = rho * internal_e * gm1;
       });
-}
+a
 
 void TabularCooling::TownsendSrcTerm(parthenon::MeshData<parthenon::Real> *md,
                                      const parthenon::Real dt_) const {
@@ -601,7 +607,13 @@ Real TabularCooling::EstimateTimeStep(MeshData<Real> *md) const {
   const auto log_lambdas = log_lambdas_;
 
   const Real gm1 = gm1_;
-  const auto internal_e_floor = T_floor_ / mu_m_u_gm1_by_k_B;
+
+  //Determine the cooling floor, whichever is higher of the cooling table floor
+  //or fluid solver floor
+  const auto temp_cool_floor = std::pow(10.0, log_temp_start_); // low end of cool table
+  const Real temp_floor =  (T_floor_ > temp_cool_floor) T_floor ? temp_cool_floor;
+
+  const Real internal_e_floor = temp_floor / mu_m_u_gm1_by_k_B; // specific internal en.
 
   // Grab some necessary variables
   const auto &prim_pack = md->PackVariables(std::vector<std::string>{"prim"});

--- a/src/hydro/srcterms/tabular_cooling.cpp
+++ b/src/hydro/srcterms/tabular_cooling.cpp
@@ -298,10 +298,10 @@ void TabularCooling::SubcyclingFixedIntSrcTerm(MeshData<Real> *md, const Real dt
 
   const Real d_e_tol = d_e_tol_;
 
-  //Determine the cooling floor, whichever is higher of the cooling table floor
-  //or fluid solver floor
+  // Determine the cooling floor, whichever is higher of the cooling table floor
+  // or fluid solver floor
   const auto temp_cool_floor = std::pow(10.0, log_temp_start_); // low end of cool table
-  const Real temp_floor =  (T_floor_ > temp_cool_floor)? T_floor_ : temp_cool_floor;
+  const Real temp_floor = (T_floor_ > temp_cool_floor) ? T_floor_ : temp_cool_floor;
 
   const Real internal_e_floor = temp_floor / mu_m_u_gm1_by_k_B; // specific internal en.
 
@@ -608,10 +608,10 @@ Real TabularCooling::EstimateTimeStep(MeshData<Real> *md) const {
 
   const Real gm1 = gm1_;
 
-  //Determine the cooling floor, whichever is higher of the cooling table floor
-  //or fluid solver floor
+  // Determine the cooling floor, whichever is higher of the cooling table floor
+  // or fluid solver floor
   const auto temp_cool_floor = std::pow(10.0, log_temp_start_); // low end of cool table
-  const Real temp_floor =  (T_floor_ > temp_cool_floor)? T_floor_ : temp_cool_floor;
+  const Real temp_floor = (T_floor_ > temp_cool_floor) ? T_floor_ : temp_cool_floor;
 
   const Real internal_e_floor = temp_floor / mu_m_u_gm1_by_k_B; // specific internal en.
 

--- a/src/hydro/srcterms/tabular_cooling.hpp
+++ b/src/hydro/srcterms/tabular_cooling.hpp
@@ -115,7 +115,7 @@ class TabularCooling {
 
   CoolIntegrator integrator_;
 
-  // Temperature floor (assumed in Kelvin and only used in cooling function)
+  // Temperature floor of the fluid solver (assumed in Kelvin)
   parthenon::Real T_floor_;
 
   // Maximum number of iterations/subcycles

--- a/src/hydro/srcterms/tabular_cooling.hpp
+++ b/src/hydro/srcterms/tabular_cooling.hpp
@@ -84,7 +84,7 @@ struct RK45Stepper {
   }
 };
 
-enum class CoolIntegrator { undefined, rk12, rk45, mixed, townsend };
+enum class CoolIntegrator { undefined, rk12, rk45, townsend };
 
 class TabularCooling {
  private:
@@ -189,10 +189,6 @@ class TabularCooling {
 
   void SrcTerm(parthenon::MeshData<parthenon::Real> *md, const parthenon::Real dt) const;
 
-  // Mixed integration scheme, i.e., try RK12 first and if error is too large
-  // switch to RK45 with adaptive timestepping
-  void MixedIntSrcTerm(parthenon::MeshData<parthenon::Real> *md,
-                       const parthenon::Real dt) const;
   // Townsend 2009 exact integration scheme
   void TownsendSrcTerm(parthenon::MeshData<parthenon::Real> *md,
                        const parthenon::Real dt) const;


### PR DESCRIPTION
I now implemented the changes we discussed in our last call, i.e.,
- the cooling cfl is now independent on the integrator (and just checks that the entries in the table are equally spaced)
- the pressure floor takes precedence in the `ConsToPrim` call (but the Tfloor is also called afterwards if both are present)
- in the cooling functions, only the Tfloor counts (not the pressure floor) 

In addition, I 
- documented cooling and floor parameters
- bumped Parthenon to include support for Ascent output
- removed the "mixed" integrator, which I put there some time ago but never really tested

If you're fine with those changes, feel free to merge and then merge the new `main` into the cluster branch.
If there are issues, I'll likely first be able to address them on/after 6 Mar.