### PR TITLE
Fix output.md docs path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Some example input files are provided in the [inputs](inputs/) folder.
 
 There exit several options to read/process data written by AthenaPK -- specifically in
 the `file_type = hdf5` format, see
-[Parthenon doc](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/docs/outputs.md):
+[Parthenon doc](https://github.com/parthenon-hpc-lab/parthenon/blob/stable/docs/outputs.md):
 
 1. With [ParaView](https://www.paraview.org/) and
 [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/).

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Some example input files are provided in the [inputs](inputs/) folder.
 
 There exit several options to read/process data written by AthenaPK -- specifically in
 the `file_type = hdf5` format, see
-[Parthenon doc](https://github.com/parthenon-hpc-lab/parthenon/blob/stable/docs/outputs.md):
+[Parthenon doc](https://parthenon-hpc-lab.github.io/parthenon/develop/src/outputs.html):
 
 1. With [ParaView](https://www.paraview.org/) and
 [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/).


### PR DESCRIPTION
The commit [dd460b4](https://github.com/parthenon-hpc-lab/athenapk/pull/34/commits/dd460b42fa6d423756d119f42b7c2e65f4c74bef) is directly pulled from upstream. Only review another.


4042b3c Fixes the the output.md path which exists in stable branch, not develop branch