### PR TITLE
Throw exception on invalid problem id

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2020-2021, Athena Parthenon Collaboration. All rights reserved.
 // Licensed under the 3-Clause License (the "LICENSE");
 
+#include <sstream>
+
 // Parthenon headers
 #include "globals.hpp"
 #include "parthenon_manager.hpp"
@@ -9,7 +11,8 @@
 // AthenaPK headers
 #include "hydro/hydro.hpp"
 #include "hydro/hydro_driver.hpp"
-#include "main.hpp"
+//#include "main.hpp"
+
 #include "pgen/pgen.hpp"
 // Initialize defaults for package specific callback functions
 namespace Hydro {
@@ -42,6 +45,7 @@ int main(int argc, char *argv[]) {
   // Redefine defaults
   pman.app_input->ProcessPackages = Hydro::ProcessPackages;
   const auto problem = pman.pinput->GetOrAddString("job", "problem_id", "unset");
+
   if (problem == "linear_wave") {
     pman.app_input->InitUserMeshData = linear_wave::InitUserMeshData;
     pman.app_input->ProblemGenerator = linear_wave::ProblemGenerator;
@@ -91,7 +95,13 @@ int main(int argc, char *argv[]) {
     Hydro::ProblemSourceFirstOrder = turbulence::Driving;
     pman.app_input->InitMeshBlockUserData = turbulence::SetPhases;
     pman.app_input->MeshBlockUserWorkBeforeOutput = turbulence::UserWorkBeforeOutput;
+  } else {
+    // parthenon throw error message for the invalid problem
+    std::stringstream msg;
+    msg << "Problem ID '" << problem << "' is not implemented yet.";
+    PARTHENON_THROW(msg);
   }
+
 
   pman.ParthenonInitPackagesAndMesh();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 // AthenaPK headers
 #include "hydro/hydro.hpp"
 #include "hydro/hydro_driver.hpp"
-//#include "main.hpp"
+#include "main.hpp"
 
 #include "pgen/pgen.hpp"
 // Initialize defaults for package specific callback functions
@@ -101,7 +101,6 @@ int main(int argc, char *argv[]) {
     msg << "Problem ID '" << problem << "' is not implemented yet.";
     PARTHENON_THROW(msg);
   }
-
 
   pman.ParthenonInitPackagesAndMesh();
 


### PR DESCRIPTION
Earlier it continue with invalid parameters and then exists. This PR saves unnecessary process cycles and fails fast if problem_id is invalid


```
$ build/bin/athenaPK -i inputs/invalid_test.in -d /tmp
terminate called after throwing an instance of 'std::runtime_error'
  what():  ### PARTHENON ERROR
  Message:     Problem ID 'tbhaxor' is not implemented yet.
  File:        /mnt/Projects/athenapk/src/main.cpp
  Line number: 102

[h3ll:74034] *** Process received signal ***
[h3ll:74034] Signal: Aborted (6)
[h3ll:74034] Signal code:  (-6)
... error continues
```