### PR TITLE
[CI only] reproducer for Ascent vorticity bug

### DIFF
--- a/inputs/ascent_actions.yaml
+++ b/inputs/ascent_actions.yaml
@@ -1,0 +1,62 @@
+-
+  action: "add_pipelines"
+  pipelines: 
+    velocity_pl: # compute velocity magnitude
+      f1: 
+        type: "composite_vector"
+        params: 
+          field1: "prim_velocity_1"
+          field2: "prim_velocity_2"
+          field3: "prim_velocity_3"
+          output_name: "velocity_vec"
+      f3:
+        type: "vector_magnitude"
+        params:
+          field: "velocity_vec"
+          output_name: "velocity_mag"
+          
+    vorticity_pl: # compute vorticity magnitude
+      f1: 
+        type: "composite_vector"
+        params: 
+          field1: "prim_velocity_1"
+          field2: "prim_velocity_2"
+          field3: "prim_velocity_3"
+          output_name: "velocity_vec"
+      f2:
+        type: "vorticity"
+        params:
+          field: "velocity_vec"
+          output_name: "vorticity_vec"
+      f3:
+        type: "vector_magnitude"
+        params:
+          field: "vorticity_vec"
+          output_name: "vorticity_mag"
+      f4:
+        type: "recenter"
+        params:
+          field: "vorticity_mag"
+          association: "element"
+
+-
+  action: "add_queries"
+  queries: 
+    density_binning:
+      params: 
+        expression: "binning('prim_density', 'avg', [axis('cell_radius', num_bins=20)])"
+        name: "density_profile"
+
+    vorticity_binning: # this currently does not work due to an Ascent bug
+      params: 
+        expression: "binning('vorticity_mag', 'avg', [axis('cell_radius', num_bins=20)])"
+        name: "vorticity_profile"
+      pipeline: "vorticity_pl"
+
+    velocity_binning: # must be the last query (to work around an Ascent bug)
+      params: 
+        expression: "binning('velocity_mag', 'avg', [axis('cell_radius', num_bins=20)])"
+        name: "velocity_profile"
+      pipeline: "velocity_pl"
+-
+  action: "save_session"

--- a/inputs/ascent_actions.yaml
+++ b/inputs/ascent_actions.yaml
@@ -44,18 +44,23 @@
   queries: 
     density_binning:
       params: 
-        expression: "binning('prim_density', 'avg', [axis('cell_radius', num_bins=20)])"
+        expression: "binning('prim_density', 'avg', [axis('cell_radius', num_bins=100)])"
         name: "density_profile"
+
+    pressure_binning:
+      params: 
+        expression: "binning('prim_pressure', 'avg', [axis('cell_radius', num_bins=100)])"
+        name: "pressure_profile"
 
     vorticity_binning: # this currently does not work due to an Ascent bug
       params: 
-        expression: "binning('vorticity_mag', 'avg', [axis('cell_radius', num_bins=20)])"
+        expression: "binning('vorticity_mag', 'avg', [axis('cell_radius', num_bins=100)])"
         name: "vorticity_profile"
       pipeline: "vorticity_pl"
 
     velocity_binning: # must be the last query (to work around an Ascent bug)
       params: 
-        expression: "binning('velocity_mag', 'avg', [axis('cell_radius', num_bins=20)])"
+        expression: "binning('velocity_mag', 'avg', [axis('cell_radius', num_bins=100)])"
         name: "velocity_profile"
       pipeline: "velocity_pl"
 -

--- a/inputs/reproducer.in
+++ b/inputs/reproducer.in
@@ -74,5 +74,5 @@ variables = cons
 
 <parthenon/output1>
 file_type = ascent
-actions_file = inputs/ascent_actions_vorticity_binning_bug.yaml
+actions_file = inputs/ascent_actions.yaml
 dt = 0.05

--- a/inputs/reproducer.in
+++ b/inputs/reproducer.in
@@ -38,8 +38,8 @@ nx3=16
 
 <parthenon/time>
 integrator = vl2
-cfl = 0.25
-tlim = 1.0
+cfl = 0.2
+tlim = 0.1
 nlim = 100000
 perf_cycle_offset = 2 # number of inital cycles not to be included in perf calc
 ncycle_out_mesh = -100
@@ -59,7 +59,7 @@ threshold_pressure_gradient  = 0.1
 # initialize a Sedov test problem using parameters from Richard Klein and J. Bolstad
 # [Reference: J.R. Kamm and F.X. Timmes,
 #    On Efficient Generation of Numerically Robust Sedov Solutions, LA-UR-07-2849.]
-#
+# (At t = 1, the shock radius is R_s = 1.)
 <problem/blast>
 pressure_ambient  = 2.6631008890474766e-07   # ambient pressure
 pressure_ratio    = 1.0e10  # initial pressure ratio
@@ -70,10 +70,10 @@ density_ratio     = 1.0     # density ratio
 
 <parthenon/output0>
 file_type = hdf5
-dt = 0.1
+dt = 0.01
 variables = prim
 
 <parthenon/output1>
 file_type = ascent
 actions_file = inputs/ascent_actions.yaml
-dt = 0.1
+dt = 0.01

--- a/inputs/reproducer.in
+++ b/inputs/reproducer.in
@@ -1,0 +1,78 @@
+# AthenaPK - a performance portable block structured AMR MHD code
+# Copyright (c) 2020, Athena Parthenon Collaboration. All rights reserved.
+# Licensed under the BSD 3-Clause License (the "LICENSE");
+
+<comment>
+problem = spherical blast wave
+
+<job>
+problem_id = blast
+
+<parthenon/mesh>
+refinement = adaptive
+numlevel = 3
+nghost = 4
+
+nx1 = 32
+x1min = -0.5
+x1max = 0.5
+ix1_bc = periodic
+ox1_bc = periodic
+
+nx2 = 32
+x2min = -0.5
+x2max = 0.5
+ix2_bc = periodic
+ox2_bc = periodic
+
+nx3 = 32
+x3min = -0.5
+x3max = 0.5
+ix3_bc = periodic
+ox3_bc = periodic
+
+<parthenon/meshblock>
+nx1=16
+nx2=16
+nx3=16
+
+<parthenon/time>
+integrator = vl2
+cfl = 0.25
+tlim = 1.0
+nlim = 100000
+perf_cycle_offset = 2 # number of inital cycles not to be included in perf calc
+ncycle_out_mesh = -100
+
+<hydro>
+eos = adiabatic
+riemann = hlle
+reconstruction = ppm
+gamma = 1.4
+scratch_level = 0 # 0 is actual scratch (tiny); 1 is HBM
+
+<refinement>
+type                         = pressure_gradient
+threshold_pressure_gradient  = 0.1
+
+# initialize a Sedov test problem using parameters from Richard Klein and J. Bolstad
+# [Reference: J.R. Kamm and F.X. Timmes,
+#    On Efficient Generation of Numerically Robust Sedov Solutions, LA-UR-07-2849.]
+#
+<problem/blast>
+pressure_ambient  = 2.6631008890474766e-07   # ambient pressure
+pressure_ratio    = 1.0e10  # initial pressure ratio
+radius_outer      = 0.03125 # Radius of the outer sphere
+radius_inner      = 0.0     # Radius of the inter sphere (with ramp between inner and outer sphere)
+density_ambient   = 1.0     # ambient density
+density_ratio     = 1.0     # density ratio
+
+<parthenon/output0>
+file_type = hdf5
+dt = 0.05
+variables = cons
+
+<parthenon/output1>
+file_type = ascent
+actions_file = inputs/ascent_actions_vorticity_binning_bug.yaml
+dt = 0.05

--- a/inputs/reproducer.in
+++ b/inputs/reproducer.in
@@ -67,12 +67,7 @@ radius_inner      = 0.0     # Radius of the inter sphere (with ramp between inne
 density_ambient   = 1.0     # ambient density
 density_ratio     = 1.0     # density ratio
 
-<parthenon/output0>
-file_type = hdf5
-dt = 0.05
-variables = cons
-
 <parthenon/output1>
 file_type = ascent
 actions_file = inputs/ascent_actions.yaml
-dt = 0.05
+dt = 0.1

--- a/inputs/reproducer.in
+++ b/inputs/reproducer.in
@@ -47,8 +47,9 @@ ncycle_out_mesh = -100
 <hydro>
 eos = adiabatic
 riemann = hlle
-reconstruction = ppm
+reconstruction = plm
 gamma = 1.4
+first_order_flux_correct = true 
 scratch_level = 0 # 0 is actual scratch (tiny); 1 is HBM
 
 <refinement>
@@ -63,9 +64,14 @@ threshold_pressure_gradient  = 0.1
 pressure_ambient  = 2.6631008890474766e-07   # ambient pressure
 pressure_ratio    = 1.0e10  # initial pressure ratio
 radius_outer      = 0.03125 # Radius of the outer sphere
-radius_inner      = 0.0     # Radius of the inter sphere (with ramp between inner and outer sphere)
+radius_inner      = 0.03125 # Radius of the inter sphere (with ramp between inner and outer sphere)
 density_ambient   = 1.0     # ambient density
 density_ratio     = 1.0     # density ratio
+
+<parthenon/output0>
+file_type = hdf5
+dt = 0.1
+variables = prim
 
 <parthenon/output1>
 file_type = ascent

--- a/plot_ascent_profiles.py
+++ b/plot_ascent_profiles.py
@@ -38,9 +38,9 @@ def plot_profile(name, session=None):
 if __name__ == "__main__":
     # plot profiles produced by Ascent DataBinning function
     
-    with open("ascent_profiles.yaml", 'r') as file:
+    with open("ascent_session.yaml", 'r') as file:
         session = yaml.load(file, Loader=yaml.FullLoader)
         plot_profile("density_profile", session=session)
-        plot_profile("pressure_profile", session=session)
+        #plot_profile("pressure_profile", session=session)
         plot_profile("vorticity_profile", session=session)
 

--- a/plot_ascent_profiles.py
+++ b/plot_ascent_profiles.py
@@ -2,7 +2,7 @@ import yaml
 import numpy as np
 import matplotlib.pyplot as plt
 
-def plot_profile(name, session=None):
+def plot_profile(name, session=None, log=False):
     data = session[name]
     profiles = []
     times = []
@@ -26,9 +26,11 @@ def plot_profile(name, session=None):
     plt.figure(figsize=(6, 4))
     for i in range(len(profiles)):
         plt.plot(bin_centers[i], profiles[i],
-                 label=r"$t = {:.5f}$".format(times[i]))
+                 label=r"$t = {:.2f}$".format(times[i]))
 
     plt.xlim(0, 0.5)
+    if (log):
+        plt.yscale('log')
     plt.legend(loc='upper right')
     plt.ylabel(f"{name}")
     plt.xlabel(r"radius")
@@ -41,6 +43,6 @@ if __name__ == "__main__":
     with open("ascent_session.yaml", 'r') as file:
         session = yaml.load(file, Loader=yaml.FullLoader)
         plot_profile("density_profile", session=session)
-        plot_profile("pressure_profile", session=session)
+        plot_profile("pressure_profile", session=session, log=True)
         plot_profile("vorticity_profile", session=session)
 

--- a/plot_ascent_profiles.py
+++ b/plot_ascent_profiles.py
@@ -31,7 +31,7 @@ def plot_profile(name, session=None, log=False):
     plt.xlim(0, 0.5)
     if (log):
         plt.yscale('log')
-    plt.legend(loc='upper right')
+    plt.legend(loc='upper left')
     plt.ylabel(f"{name}")
     plt.xlabel(r"radius")
     plt.tight_layout()

--- a/plot_ascent_profiles.py
+++ b/plot_ascent_profiles.py
@@ -41,6 +41,6 @@ if __name__ == "__main__":
     with open("ascent_session.yaml", 'r') as file:
         session = yaml.load(file, Loader=yaml.FullLoader)
         plot_profile("density_profile", session=session)
-        #plot_profile("pressure_profile", session=session)
+        plot_profile("pressure_profile", session=session)
         plot_profile("vorticity_profile", session=session)
 

--- a/plot_ascent_profiles.py
+++ b/plot_ascent_profiles.py
@@ -1,0 +1,46 @@
+import yaml
+import numpy as np
+import matplotlib.pyplot as plt
+
+def plot_profile(name, session=None):
+    data = session[name]
+    profiles = []
+    times = []
+    bin_centers = []
+
+    # loop over output times
+    for cycle in data.values():
+        # compute bins
+        bin_props = cycle['attrs']['bin_axes']['value']['cell_radius']
+        xmin = bin_props['min_val']
+        xmax = bin_props['max_val']
+        nbins = bin_props['num_bins']
+        bins = np.linspace(xmin, xmax, nbins+1)
+        bin_centers.append(0.5*(bins[:-1] + bins[1:]))
+
+        # get profile
+        profiles.append(np.asarray(
+            cycle['attrs']['value']['value'], dtype=np.float64))
+        times.append(cycle['time'])
+
+    plt.figure(figsize=(6, 4))
+    for i in range(len(profiles)):
+        plt.plot(bin_centers[i], profiles[i],
+                 label=r"$t = {:.5f}$".format(times[i]))
+
+    plt.xlim(0, 0.5)
+    plt.legend(loc='upper right')
+    plt.ylabel(f"{name}")
+    plt.xlabel(r"radius")
+    plt.tight_layout()
+    plt.savefig(name + ".png")
+
+if __name__ == "__main__":
+    # plot profiles produced by Ascent DataBinning function
+    
+    with open("ascent_profiles.yaml", 'r') as file:
+        session = yaml.load(file, Loader=yaml.FullLoader)
+        plot_profile("density_profile", session=session)
+        plot_profile("pressure_profile", session=session)
+        plot_profile("vorticity_profile", session=session)
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,7 @@ int main(int argc, char *argv[]) {
     pman.app_input->InitUserMeshData = blast::InitUserMeshData;
     pman.app_input->ProblemGenerator = blast::ProblemGenerator;
     pman.app_input->UserWorkAfterLoop = blast::UserWorkAfterLoop;
+    pman.app_input->MeshBlockUserWorkBeforeOutput = blast::UserWorkBeforeOutput;
   } else if (problem == "advection") {
     pman.app_input->InitUserMeshData = advection::InitUserMeshData;
     pman.app_input->ProblemGenerator = advection::ProblemGenerator;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,7 @@ int main(int argc, char *argv[]) {
     pman.app_input->ProblemGenerator = blast::ProblemGenerator;
     pman.app_input->UserWorkAfterLoop = blast::UserWorkAfterLoop;
     pman.app_input->MeshBlockUserWorkBeforeOutput = blast::UserWorkBeforeOutput;
+    Hydro::ProblemInitPackageData = blast::ProblemInitPackageData;
   } else if (problem == "advection") {
     pman.app_input->InitUserMeshData = advection::InitUserMeshData;
     pman.app_input->ProblemGenerator = advection::ProblemGenerator;

--- a/src/pgen/blast.cpp
+++ b/src/pgen/blast.cpp
@@ -205,4 +205,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 void UserWorkAfterLoop(Mesh *mesh, ParameterInput *pin, parthenon::SimTime &tm) {
   image_data = {};
 }
+
+void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin) {}
+
 } // namespace blast

--- a/src/pgen/pgen.hpp
+++ b/src/pgen/pgen.hpp
@@ -53,6 +53,7 @@ void ProblemGenerator(MeshBlock *pmb, parthenon::ParameterInput *pin);
 void UserWorkAfterLoop(Mesh *mesh, parthenon::ParameterInput *pin,
                        parthenon::SimTime &tm);
 void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin);
+void ProblemInitPackageData(ParameterInput *pin, parthenon::StateDescriptor *pkg);
 } // namespace blast
 
 namespace advection {

--- a/src/pgen/pgen.hpp
+++ b/src/pgen/pgen.hpp
@@ -52,6 +52,7 @@ void InitUserMeshData(Mesh *mesh, ParameterInput *pin);
 void ProblemGenerator(MeshBlock *pmb, parthenon::ParameterInput *pin);
 void UserWorkAfterLoop(Mesh *mesh, parthenon::ParameterInput *pin,
                        parthenon::SimTime &tm);
+void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin);
 } // namespace blast
 
 namespace advection {


### PR DESCRIPTION
**This is fixed in Ascent-0.9.2.**

Recipe:
```
git clone --recursive https://github.com/parthenon-hpc-lab/athenapk.git
cd athenapk
git checkout ascent-vorticity-reproducer
mkdir build && cd build
cmake .. -DKokkos_ENABLE_OPENMP=OFF -DKokkos_ENABLE_SERIAL=ON -DPARTHENON_ENABLE_ASCENT=ON -DAscent_DIR=$ASCENT_HOME/install/ascent-develop/lib/cmake/ascent
make -j6
cd ..
mpirun -np 8 ./build/bin/athenaPK -i inputs/reproducer.in
python3 plot_ascent_profiles.py
```

Error message:
```
 Skipping.Field type unsupported for conversion to blueprint.
   gradient assoc= Points valueType=vtkm::Vec<vtkm::Vec<double, 3>, 3> storageType=vtkm::cont::StorageTagBasic 15625 values occupying 1125000 bytes [((1.11588e-169,4.39685e-152,-2.65875e-180),(-2.47755e-165,2.03444e-153,1.78584e-175),(1.11598e-169,-1.03699e-153,-2.65879e-180)) ((1.11588e-169,4.46591e-152,-2.65877e-180),(-1.23877e-165,1.01732e-153,8.92925e-176),(5.57991e-170,1.55873e-154,-1.32941e-180)) ((5.57941e-170,2.33658e-152,-1.32941e-180),(-1.70865e-171,1.04028e-157,5.33424e-181),(2.01823e-176,6.74664e-154,-1.79718e-185)) ... ((-1.0925e-286,-3.55353e-187,0),(1.05288e-302,-6.90374e-192,0),(1.05293e-302,1.00726e-189,0)) ((-1.05293e-302,-9.958e-190,0),(0,-2.26873e-194,0),(0,7.45482e-193,0)) ((0,-1.5415e-192,0),(0,-1.7697e-194,0),(0,-3.4684e-194,0))]
```