### PR TITLE
Add initial pertubation for cluster pgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 AthenaPK: a performance portable version based on [Athena++](https://github.com/PrincetonUniversity/athena),  [Parthenon](https://github.com/parthenon-hpc-lab/parthenon) and [Kokkos](https://github.com/kokkos/kokkos).
 
-## Current state of the code
+## Overview
 
-For this reason, it is highly recommended to only use AthenaPK with the Kokkos and Parthenon versions that are provided by the submodules (see [building](#building)) and to build everything (AthenaPK, Parthenon, and Kokkos) together from source.
+It is highly recommended to only use AthenaPK with the Kokkos and Parthenon versions that are provided by the submodules (see [building](#building)) and to build everything (AthenaPK, Parthenon, and Kokkos) together from source.
 Neither other versions or nor using preinstalled Parthenon/Kokkos libraries have been tested.
 
 Current features include
@@ -76,19 +76,22 @@ Obtain all (AthenaPK, Parthenon, and Kokkos) sources
 Most of the general build instructions and options for Parthenon (see [here](https://parthenon-hpc-lab.github.io/parthenon/develop/src/building.html)) also apply to AthenaPK.
 The following examples are a few standard cases.
 
-Most simple configuration (only CPU, no MPI, no HDF5).
+Most simple configuration (only CPU, no MPI).
 The `Kokkos_ARCH_...` parameter should be adjusted to match the target machine where AthenaPK will be executed.
 A full list of architecture keywords is available on the [Kokkos wiki](https://kokkos.github.io/kokkos-core-wiki/keywords.html#architecture-keywords).
 
-
-    # configure with enabling Broadwell architecture (AVX2) instructions
-    cmake -S. -Bbuild-host -DKokkos_ARCH_BDW=ON -DPARTHENON_DISABLE_MPI=ON -DPARTHENON_DISABLE_HDF5=ON
+    # configure with enabling Intel Broadwell or similar architecture (AVX2) instructions
+    cmake -S. -Bbuild-host -DKokkos_ARCH_BDW=ON -DPARTHENON_DISABLE_MPI=ON
     # now build with
     cd build-host && make
     # or alternatively
     cmake --build build-host
 
-An Intel Skylake system (AVX512 instructions) with NVidia Volta V100 GPUs and with MPI and HDF5 enabled (the latter is the default option, so they don't need to be specified)
+If `cmake` has troubling finding the HDF5 library (which is required for writing analysis outputs or
+restartings simulation) an additional hint to the location of the library can be provided via
+`-DHDF5_ROOT=/path/to/local/hdf5` on the first `cmake` command for configuration.
+
+An Intel Skylake system (AVX512 instructions) with NVidia Volta V100 GPUs and with MPI enabled (the latter is the default option, so they don't need to be specified)
 
     cmake -S. -Bbuild-gpu -DKokkos_ARCH_SKX=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON
     # now build with

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -162,6 +162,39 @@ r_sampling = 4.0
 Specifically, the resolution of the 1D profile for each meshblock is either
 `min(dx,dy,dz)/r_sampling` or `r_k/r_sampling`, whichever is smaller.
 
+## Initial perturbations
+
+Initial perturbations for both the velocity field and the magnetic field are
+supported.
+
+*Note* that these intial perturbation are currently incompatible with
+other initial conditions that modify the velocity or magnetic field, e.g.,
+an initial magnetic dipole or a uniform field.
+This restriction could be lifted if required/desired but the normalization
+of the fields would need to be adjusted.
+
+In general, the perturbations will be seeded by an inverse parabolic
+spectral profile centered on a peak wavenumber (in normalized units, i.e.,
+`k_peak = 2` mean half the box size) with a finite number of modes (default 40)
+randomly chosen between `k_peak/2` and `2*k_peak`.
+
+Pertubations are controlled by the following parameters:
+```
+<problem/cluster/init_perturb>
+# for the velocity field
+sigma_v = 0.0      # in code velocity; default: 0.0 (disabled)
+k_peak_v = ???     # wavenumber in normalized units where the velocity spectrum peaks. No default value.
+num_modes_v = 40   # (optional) number of wavemodes in spectral space; default: 40
+sol_weight_v = 1.0 # (optional) power in solenoidal (rotational) modes of the perturbation. Range between 0 (fully compressive) and 1.0 (default, fully solenoidal).
+rseed_v = 1        # (optional) integer seed for RNG for wavenumbers and amplitudes
+
+# for the magnetic field
+sigma_b = 0.0      # in code magnetic; default: 0.0 (disabled)
+k_peak_b = ???     # wavenumber in normalized units where the magnetic field spectrum peaks. No default value.
+num_modes_b = 40   # (optional) number of wavemodes in spectral space; default: 40
+rseed_b = 2        # (optional) integer seed for RNG for wavenumbers and amplitudes
+```
+
 ## AGN Triggering
 
 If AGN triggering is enabled, at the end of each time step, a mass accretion

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -182,14 +182,14 @@ Pertubations are controlled by the following parameters:
 ```
 <problem/cluster/init_perturb>
 # for the velocity field
-sigma_v = 0.0      # in code velocity; default: 0.0 (disabled)
+sigma_v = 0.0      # volume weighted RMS |v| in code velocity; default: 0.0 (disabled)
 k_peak_v = ???     # wavenumber in normalized units where the velocity spectrum peaks. No default value.
 num_modes_v = 40   # (optional) number of wavemodes in spectral space; default: 40
 sol_weight_v = 1.0 # (optional) power in solenoidal (rotational) modes of the perturbation. Range between 0 (fully compressive) and 1.0 (default, fully solenoidal).
 rseed_v = 1        # (optional) integer seed for RNG for wavenumbers and amplitudes
 
 # for the magnetic field
-sigma_b = 0.0      # in code magnetic; default: 0.0 (disabled)
+sigma_b = 0.0      # volume weighted RMS |B| in code magnetic; default: 0.0 (disabled)
 k_peak_b = ???     # wavenumber in normalized units where the magnetic field spectrum peaks. No default value.
 num_modes_b = 40   # (optional) number of wavemodes in spectral space; default: 40
 rseed_b = 2        # (optional) integer seed for RNG for wavenumbers and amplitudes

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
         hydro/srcterms/tabular_cooling.cpp
         refinement/gradient.cpp
         refinement/other.cpp
+        utils/few_modes_ft.cpp
 )
 
 add_subdirectory(pgen)

--- a/src/eos/adiabatic_glmmhd.hpp
+++ b/src/eos/adiabatic_glmmhd.hpp
@@ -24,8 +24,10 @@ using parthenon::Real;
 class AdiabaticGLMMHDEOS : public EquationOfState {
  public:
   AdiabaticGLMMHDEOS(Real pressure_floor, Real density_floor, Real internal_e_floor,
-                     Real gamma)
-      : EquationOfState(pressure_floor, density_floor, internal_e_floor), gamma_{gamma} {}
+                     Real velocity_ceiling, Real internal_e_ceiling, Real gamma)
+      : EquationOfState(pressure_floor, density_floor, internal_e_floor, velocity_ceiling,
+                        internal_e_ceiling),
+        gamma_{gamma} {}
 
   void ConservedToPrimitive(MeshData<Real> *md) const override;
 
@@ -65,6 +67,9 @@ class AdiabaticGLMMHDEOS : public EquationOfState {
     auto density_floor_ = GetDensityFloor();
     auto pressure_floor_ = GetPressureFloor();
     auto e_floor_ = GetInternalEFloor();
+
+    auto velocity_ceiling_ = GetVelocityCeiling();
+    auto e_ceiling_ = GetInternalECeiling();
 
     Real &u_d = cons(IDN, k, j, i);
     Real &u_m1 = cons(IM1, k, j, i);
@@ -109,6 +114,23 @@ class AdiabaticGLMMHDEOS : public EquationOfState {
     Real e_B = 0.5 * (SQR(u_b1) + SQR(u_b2) + SQR(u_b3));
     w_p = gm1 * (u_e - e_k - e_B);
 
+    // apply velocity ceiling. By default ceiling is std::numeric_limits<Real>::infinity()
+    const Real w_v2 = SQR(w_vx) + SQR(w_vy) + SQR(w_vz);
+    if (w_v2 > SQR(velocity_ceiling_)) {
+      const Real w_v = sqrt(w_v2);
+      w_vx *= velocity_ceiling_ / w_v;
+      w_vy *= velocity_ceiling_ / w_v;
+      w_vz *= velocity_ceiling_ / w_v;
+
+      u_m1 *= velocity_ceiling_ / w_v;
+      u_m2 *= velocity_ceiling_ / w_v;
+      u_m3 *= velocity_ceiling_ / w_v;
+
+      Real e_k_new = 0.5 * u_d * SQR(velocity_ceiling_);
+      u_e -= e_k - e_k_new;
+      e_k = e_k_new;
+    }
+
     // Let's apply floors explicitly, i.e., by default floor will be disabled (<=0)
     // and the code will fail if a negative pressure is encountered.
     PARTHENON_REQUIRE(w_p > 0.0 || pressure_floor_ > 0.0 || e_floor_ > 0.0,
@@ -128,6 +150,14 @@ class AdiabaticGLMMHDEOS : public EquationOfState {
       // apply temperature floor, correct total energy
       u_e = (u_d * e_floor_) + e_k + e_B;
       w_p = eff_pressure_floor;
+    }
+
+    // temperature (internal energy) based pressure ceiling
+    const Real eff_pressure_ceiling = gm1 * u_d * e_ceiling_;
+    if (w_p > eff_pressure_ceiling) {
+      // apply temperature ceiling, correct total energy
+      u_e = (u_d * e_ceiling_) + e_k + e_B;
+      w_p = eff_pressure_ceiling;
     }
 
     // Convert passive scalars

--- a/src/eos/adiabatic_hydro.hpp
+++ b/src/eos/adiabatic_hydro.hpp
@@ -25,8 +25,10 @@ using parthenon::Real;
 class AdiabaticHydroEOS : public EquationOfState {
  public:
   AdiabaticHydroEOS(Real pressure_floor, Real density_floor, Real internal_e_floor,
-                    Real gamma)
-      : EquationOfState(pressure_floor, density_floor, internal_e_floor), gamma_{gamma} {}
+                    Real velocity_ceiling, Real internal_e_ceiling, Real gamma)
+      : EquationOfState(pressure_floor, density_floor, internal_e_floor, velocity_ceiling,
+                        internal_e_ceiling),
+        gamma_{gamma} {}
 
   void ConservedToPrimitive(MeshData<Real> *md) const override;
 
@@ -54,6 +56,9 @@ class AdiabaticHydroEOS : public EquationOfState {
     auto density_floor_ = GetDensityFloor();
     auto pressure_floor_ = GetPressureFloor();
     auto e_floor_ = GetInternalEFloor();
+
+    auto velocity_ceiling_ = GetVelocityCeiling();
+    auto e_ceiling_ = GetInternalECeiling();
 
     Real &u_d = cons(IDN, k, j, i);
     Real &u_m1 = cons(IM1, k, j, i);
@@ -84,6 +89,23 @@ class AdiabaticHydroEOS : public EquationOfState {
     Real e_k = 0.5 * di * (SQR(u_m1) + SQR(u_m2) + SQR(u_m3));
     w_p = gm1 * (u_e - e_k);
 
+    // apply velocity ceiling. By default ceiling is std::numeric_limits<Real>::infinity()
+    const Real w_v2 = SQR(w_vx) + SQR(w_vy) + SQR(w_vz);
+    if (w_v2 > SQR(velocity_ceiling_)) {
+      const Real w_v = sqrt(w_v2);
+      w_vx *= velocity_ceiling_ / w_v;
+      w_vy *= velocity_ceiling_ / w_v;
+      w_vz *= velocity_ceiling_ / w_v;
+
+      u_m1 *= velocity_ceiling_ / w_v;
+      u_m2 *= velocity_ceiling_ / w_v;
+      u_m3 *= velocity_ceiling_ / w_v;
+
+      Real e_k_new = 0.5 * u_d * SQR(velocity_ceiling_);
+      u_e -= e_k - e_k_new;
+      e_k = e_k_new;
+    }
+
     // Let's apply floors explicitly, i.e., by default floor will be disabled (<=0)
     // and the code will fail if a negative pressure is encountered.
     PARTHENON_REQUIRE(w_p > 0.0 || pressure_floor_ > 0.0 || e_floor_ > 0.0,
@@ -103,6 +125,14 @@ class AdiabaticHydroEOS : public EquationOfState {
       // apply temperature floor, correct total energy
       u_e = (u_d * e_floor_) + e_k;
       w_p = eff_pressure_floor;
+    }
+
+    // temperature (internal energy) based pressure ceiling
+    const Real eff_pressure_ceiling = gm1 * u_d * e_ceiling_;
+    if (w_p > eff_pressure_ceiling) {
+      // apply temperature ceiling, correct total energy
+      u_e = (u_d * e_ceiling_) + e_k;
+      w_p = eff_pressure_ceiling;
     }
 
     // Convert passive scalars

--- a/src/eos/eos.hpp
+++ b/src/eos/eos.hpp
@@ -32,9 +32,11 @@ using parthenon::Real;
 
 class EquationOfState {
  public:
-  EquationOfState(Real pressure_floor, Real density_floor, Real internal_e_floor)
+  EquationOfState(Real pressure_floor, Real density_floor, Real internal_e_floor,
+                  Real velocity_ceiling, Real internal_e_ceiling)
       : pressure_floor_(pressure_floor), density_floor_(density_floor),
-        internal_e_floor_(internal_e_floor) {}
+        internal_e_floor_(internal_e_floor), velocity_ceiling_(velocity_ceiling),
+        internal_e_ceiling_(internal_e_ceiling) {}
   virtual void ConservedToPrimitive(MeshData<Real> *md) const = 0;
 
   KOKKOS_INLINE_FUNCTION
@@ -47,8 +49,15 @@ class EquationOfState {
   KOKKOS_INLINE_FUNCTION
   Real GetInternalEFloor() const { return internal_e_floor_; }
 
+  KOKKOS_INLINE_FUNCTION
+  Real GetVelocityCeiling() const { return velocity_ceiling_; }
+
+  KOKKOS_INLINE_FUNCTION
+  Real GetInternalECeiling() const { return internal_e_ceiling_; }
+
  private:
   Real pressure_floor_, density_floor_, internal_e_floor_;
+  Real velocity_ceiling_, internal_e_ceiling_;
 };
 
 #endif // EOS_EOS_HPP_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
     Hydro::ProblemInitPackageData = rand_blast::ProblemInitPackageData;
     Hydro::ProblemSourceFirstOrder = rand_blast::RandomBlasts;
   } else if (problem == "cluster") {
-    pman.app_input->ProblemGenerator = cluster::ProblemGenerator;
+    pman.app_input->MeshProblemGenerator = cluster::ProblemGenerator;
     pman.app_input->MeshBlockUserWorkBeforeOutput = cluster::UserWorkBeforeOutput;
     Hydro::ProblemInitPackageData = cluster::ProblemInitPackageData;
     Hydro::ProblemSourceUnsplit = cluster::ClusterSrcTerm;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,10 +119,6 @@ int main(int argc, char *argv[]) {
     // This line actually runs the simulation
     driver.Execute();
   }
-  // very ugly cleanup...
-  if (problem == "turbulence") {
-    turbulence::Cleanup();
-  }
 
   // call MPI_Finalize and Kokkos::finalize if necessary
   pman.ParthenonFinalize();

--- a/src/pgen/cluster.cpp
+++ b/src/pgen/cluster.cpp
@@ -258,7 +258,7 @@ void ProblemGenerator(Mesh *pmesh, ParameterInput *pin, MeshData<Real> *md) {
   // This could be more optimized, but require a refactor of init routines being called.
   // However, given that it's just called during initial setup, this should not be a
   // performance concern.
-  for (int b; b < md->NumBlocks(); b++) {
+  for (int b = 0; b < md->NumBlocks(); b++) {
     auto pmb = md->GetBlockData(b)->GetBlockPointer();
     auto hydro_pkg = pmb->packages.Get("Hydro");
 

--- a/src/pgen/cluster.cpp
+++ b/src/pgen/cluster.cpp
@@ -32,6 +32,8 @@
 #include <parthenon/package.hpp>
 
 // AthenaPK headers
+#include "../eos/adiabatic_glmmhd.hpp"
+#include "../eos/adiabatic_hydro.hpp"
 #include "../hydro/hydro.hpp"
 #include "../hydro/srcterms/gravitational_field.hpp"
 #include "../hydro/srcterms/tabular_cooling.hpp"
@@ -54,6 +56,122 @@ using namespace parthenon::driver::prelude;
 using namespace parthenon::package::prelude;
 using utils::few_modes_ft::FewModesFT;
 
+template <class EOS>
+void ApplyClusterClips(MeshData<Real> *md, const parthenon::SimTime &tm,
+                       const Real beta_dt, const EOS eos) {
+
+  auto hydro_pkg = md->GetBlockData(0)->GetBlockPointer()->packages.Get("Hydro");
+
+  // Apply clips -- ceilings on temperature, velocity, alfven velocity, and
+  // density floor -- within a radius of the AGN
+  const auto &dfloor = hydro_pkg->Param<Real>("cluster_dfloor");
+  const auto &eceil = hydro_pkg->Param<Real>("cluster_eceil");
+  const auto &vceil = hydro_pkg->Param<Real>("cluster_vceil");
+  const auto &vAceil = hydro_pkg->Param<Real>("cluster_vAceil");
+  const auto &clip_r = hydro_pkg->Param<Real>("cluster_clip_r");
+
+  if (clip_r > 0 && (dfloor > 0 || eceil < std::numeric_limits<Real>::infinity() ||
+                     vceil < std::numeric_limits<Real>::infinity() ||
+                     vAceil < std::numeric_limits<Real>::infinity())) {
+    // Grab some necessary variables
+    const auto &prim_pack = md->PackVariables(std::vector<std::string>{"prim"});
+    const auto &cons_pack = md->PackVariables(std::vector<std::string>{"cons"});
+    IndexRange ib = md->GetBlockData(0)->GetBoundsI(IndexDomain::interior);
+    IndexRange jb = md->GetBlockData(0)->GetBoundsJ(IndexDomain::interior);
+    IndexRange kb = md->GetBlockData(0)->GetBoundsK(IndexDomain::interior);
+    const auto nhydro = hydro_pkg->Param<int>("nhydro");
+    const auto nscalars = hydro_pkg->Param<int>("nscalars");
+
+    const Real clip_r2 = SQR(clip_r);
+    const Real vceil2 = SQR(vceil);
+    const Real vAceil2 = SQR(vAceil);
+    const Real gm1 = (hydro_pkg->Param<Real>("AdiabaticIndex") - 1.0);
+
+    parthenon::par_for(
+        DEFAULT_LOOP_PATTERN, "Cluster::ApplyClusterClips", parthenon::DevExecSpace(), 0,
+        cons_pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
+          auto &cons = cons_pack(b);
+          auto &prim = prim_pack(b);
+          const auto &coords = cons_pack.GetCoords(b);
+
+          const Real r2 =
+              SQR(coords.Xc<1>(i)) + SQR(coords.Xc<2>(j)) + SQR(coords.Xc<3>(k));
+
+          if (r2 < clip_r2) {
+            // Cell falls within clipping radius
+            eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
+
+            if (dfloor > 0) {
+              const Real rho = prim(IDN, k, j, i);
+              if (rho < dfloor) {
+                cons(IDN, k, j, i) = dfloor;
+                prim(IDN, k, j, i) = dfloor;
+              }
+            }
+
+            if (vceil < std::numeric_limits<Real>::infinity()) {
+              // Apply velocity ceiling
+              const Real v2 = SQR(prim(IV1, k, j, i)) + SQR(prim(IV2, k, j, i)) +
+                              SQR(prim(IV3, k, j, i));
+              if (v2 > vceil2) {
+                // Fix the velocity to the velocity ceiling
+                const Real v = sqrt(v2);
+                cons(IM1, k, j, i) *= vceil / v;
+                cons(IM2, k, j, i) *= vceil / v;
+                cons(IM3, k, j, i) *= vceil / v;
+                prim(IV1, k, j, i) *= vceil / v;
+                prim(IV2, k, j, i) *= vceil / v;
+                prim(IV3, k, j, i) *= vceil / v;
+
+                // Remove kinetic energy
+                cons(IEN, k, j, i) -= 0.5 * prim(IDN, k, j, i) * (v2 - vceil2);
+              }
+            }
+
+            if (vAceil2 < std::numeric_limits<Real>::infinity()) {
+              // Apply Alfven velocity ceiling by raising density
+              const Real rho = prim(IDN, k, j, i);
+              const Real B2 = (SQR(prim(IB1, k, j, i)) + SQR(prim(IB2, k, j, i)) +
+                               SQR(prim(IB3, k, j, i)));
+
+              // compute Alfven mach number
+              const Real va2 = (B2 / rho);
+
+              if (va2 > vAceil2) {
+                // Increase the density to match the alfven velocity ceiling
+                const Real rho_new = std::sqrt(B2 / vAceil2);
+                cons(IDN, k, j, i) = rho_new;
+                prim(IDN, k, j, i) = rho_new;
+              }
+            }
+
+            if (eceil < std::numeric_limits<Real>::infinity()) {
+              // Apply  internal energy ceiling as a pressure ceiling
+              const Real internal_e = prim(IPR, k, j, i) / (gm1 * prim(IDN, k, j, i));
+              if (internal_e > eceil) {
+                cons(IEN, k, j, i) -= prim(IDN, k, j, i) * (internal_e - eceil);
+                prim(IPR, k, j, i) = gm1 * prim(IDN, k, j, i) * eceil;
+              }
+            }
+          }
+        });
+  }
+}
+
+void ApplyClusterClips(MeshData<Real> *md, const parthenon::SimTime &tm,
+                       const Real beta_dt) {
+  auto hydro_pkg = md->GetBlockData(0)->GetBlockPointer()->packages.Get("Hydro");
+  auto fluid = hydro_pkg->Param<Fluid>("fluid");
+  if (fluid == Fluid::euler) {
+    ApplyClusterClips(md, tm, beta_dt, hydro_pkg->Param<AdiabaticHydroEOS>("eos"));
+  } else if (fluid == Fluid::glmmhd) {
+    ApplyClusterClips(md, tm, beta_dt, hydro_pkg->Param<AdiabaticGLMMHDEOS>("eos"));
+  } else {
+    PARTHENON_FAIL("Cluster::ApplyClusterClips: Unknown EOS");
+  }
+}
+
 void ClusterSrcTerm(MeshData<Real> *md, const parthenon::SimTime &tm,
                     const Real beta_dt) {
   auto hydro_pkg = md->GetBlockData(0)->GetBlockPointer()->packages.Get("Hydro");
@@ -75,7 +193,9 @@ void ClusterSrcTerm(MeshData<Real> *md, const parthenon::SimTime &tm,
 
   const auto &snia_feedback = hydro_pkg->Param<SNIAFeedback>("snia_feedback");
   snia_feedback.FeedbackSrcTerm(md, beta_dt, tm);
-}
+
+  ApplyClusterClips(md, tm, beta_dt);
+};
 
 Real ClusterEstimateTimestep(MeshData<Real> *md) {
   Real min_dt = std::numeric_limits<Real>::max();
@@ -220,6 +340,40 @@ void ProblemInitPackageData(ParameterInput *pin, parthenon::StateDescriptor *hyd
    ************************************************************/
 
   SNIAFeedback snia_feedback(pin, hydro_pkg);
+
+  /************************************************************
+   * Read Clips  (ceilings and floors)
+   ************************************************************/
+
+  // Disable all clips by default with a negative radius clip
+  Real clip_r = pin->GetOrAddReal("problem/cluster/clips", "clip_r", -1.0);
+
+  // By default disable floors by setting a negative value
+  Real dfloor = pin->GetOrAddReal("problem/cluster/clips", "dfloor", -1.0);
+
+  // By default disable ceilings by setting to infinity
+  Real vceil = pin->GetOrAddReal("problem/cluster/clips", "vceil",
+                                 std::numeric_limits<Real>::infinity());
+  Real vAceil = pin->GetOrAddReal("problem/cluster/clips", "vAceil",
+                                  std::numeric_limits<Real>::infinity());
+  Real Tceil = pin->GetOrAddReal("problem/cluster/clips", "Tceil",
+                                 std::numeric_limits<Real>::infinity());
+  Real eceil = Tceil;
+  if (eceil < std::numeric_limits<Real>::infinity()) {
+    if (!hydro_pkg->AllParams().hasKey("mbar_over_kb")) {
+      PARTHENON_FAIL("Temperature ceiling requires units and gas composition. "
+                     "Either set a 'units' block and the 'hydro/He_mass_fraction' in "
+                     "input file or use a pressure floor "
+                     "(defined code units) instead.");
+    }
+    auto mbar_over_kb = hydro_pkg->Param<Real>("mbar_over_kb");
+    eceil = Tceil / mbar_over_kb / (hydro_pkg->Param<Real>("AdiabaticIndex") - 1.0);
+  }
+  hydro_pkg->AddParam("cluster_dfloor", dfloor);
+  hydro_pkg->AddParam("cluster_eceil", eceil);
+  hydro_pkg->AddParam("cluster_vceil", vceil);
+  hydro_pkg->AddParam("cluster_vAceil", vAceil);
+  hydro_pkg->AddParam("cluster_clip_r", clip_r);
 
   /************************************************************
    * Add derived fields
@@ -686,7 +840,7 @@ void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin) {
   // for computing temperature from primitives
   auto units = pkg->Param<Units>("units");
   auto mbar_over_kb = pkg->Param<Real>("mbar_over_kb");
-  auto mbar = mbar_over_kb*units.k_boltzmann();
+  auto mbar = mbar_over_kb * units.k_boltzmann();
 
   // fill derived vars (*including ghost cells*)
   auto &coords = pmb->coords;
@@ -712,7 +866,7 @@ void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin) {
         log10_radius(k, j, i) = 0.5 * std::log10(r2);
 
         // compute entropy
-        const Real K = P / std::pow(rho/mbar, gam);
+        const Real K = P / std::pow(rho / mbar, gam);
         entropy(k, j, i) = K;
 
         const Real v_mag = std::sqrt(SQR(v1) + SQR(v2) + SQR(v3));

--- a/src/pgen/cluster.cpp
+++ b/src/pgen/cluster.cpp
@@ -684,7 +684,9 @@ void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin) {
   auto &temperature = data->Get("temperature").data;
 
   // for computing temperature from primitives
+  auto units = pkg->Param<Units>("units");
   auto mbar_over_kb = pkg->Param<Real>("mbar_over_kb");
+  auto mbar = mbar_over_kb*units.k_boltzmann();
 
   // fill derived vars (*including ghost cells*)
   auto &coords = pmb->coords;
@@ -710,7 +712,7 @@ void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin) {
         log10_radius(k, j, i) = 0.5 * std::log10(r2);
 
         // compute entropy
-        const Real K = P / std::pow(rho, gam);
+        const Real K = P / std::pow(rho/mbar, gam);
         entropy(k, j, i) = K;
 
         const Real v_mag = std::sqrt(SQR(v1) + SQR(v2) + SQR(v3));

--- a/src/pgen/cluster.cpp
+++ b/src/pgen/cluster.cpp
@@ -755,8 +755,8 @@ void ProblemGenerator(Mesh *pmesh, ParameterInput *pin, MeshData<Real> *md) {
       few_modes_ft.SetPhases(pmb.get(), pin);
     }
     // As for t_corr in few_modes_ft, the choice for dt is
-    // in principle arbitrary because the inital v_hat is 0 and the v_hat_new will contain
-    // the perturbation (and is normalized in the following to get the desired sigma_v)
+    // in principle arbitrary because the inital b_hat is 0 and the b_hat_new will contain
+    // the perturbation (and is normalized in the following to get the desired sigma_b)
     const Real dt = 1.0;
     few_modes_ft.Generate(md, dt, "tmp_perturb");
 

--- a/src/pgen/cluster/agn_feedback.cpp
+++ b/src/pgen/cluster/agn_feedback.cpp
@@ -119,7 +119,7 @@ AGNFeedback::AGNFeedback(parthenon::ParameterInput *pin,
                                              (1 - efficiency_) * kinetic_jet_e_))) <
           10 * std::numeric_limits<Real>::epsilon(),
       "Specified kinetic jet velocity and temperature are incompatible with mass to "
-      "energy conversion efficiency. Choose either velocity or temperature.");
+      "energy conversion efficiency. Either the specified velocity, temperature, or efficiency are incompatible");
 
   PARTHENON_REQUIRE(kinetic_jet_velocity_ <=
                         units.speed_of_light() * sqrt(2 * efficiency_),

--- a/src/pgen/cluster/agn_feedback.cpp
+++ b/src/pgen/cluster/agn_feedback.cpp
@@ -17,7 +17,7 @@
 #include <parameter_input.hpp>
 #include <parthenon/package.hpp>
 
-// Athena headers
+// AthenaPK headers
 #include "../../eos/adiabatic_glmmhd.hpp"
 #include "../../eos/adiabatic_hydro.hpp"
 #include "../../main.hpp"
@@ -33,6 +33,8 @@ using namespace parthenon;
 AGNFeedback::AGNFeedback(parthenon::ParameterInput *pin,
                          parthenon::StateDescriptor *hydro_pkg)
     : fixed_power_(pin->GetOrAddReal("problem/cluster/agn_feedback", "fixed_power", 0.0)),
+      vceil_(pin->GetOrAddReal("problem/cluster/agn_feedback", "vceil",
+                               std::numeric_limits<Real>::infinity())),
       efficiency_(pin->GetOrAddReal("problem/cluster/agn_feedback", "efficiency", 1e-3)),
       thermal_fraction_(
           pin->GetOrAddReal("problem/cluster/agn_feedback", "thermal_fraction", 0.0)),
@@ -119,7 +121,8 @@ AGNFeedback::AGNFeedback(parthenon::ParameterInput *pin,
                                              (1 - efficiency_) * kinetic_jet_e_))) <
           10 * std::numeric_limits<Real>::epsilon(),
       "Specified kinetic jet velocity and temperature are incompatible with mass to "
-      "energy conversion efficiency. Either the specified velocity, temperature, or efficiency are incompatible");
+      "energy conversion efficiency. Either the specified velocity, temperature, or "
+      "efficiency are incompatible");
 
   PARTHENON_REQUIRE(kinetic_jet_velocity_ <=
                         units.speed_of_light() * sqrt(2 * efficiency_),
@@ -133,6 +136,11 @@ AGNFeedback::AGNFeedback(parthenon::ParameterInput *pin,
                     "Kinetic jet velocity must be non-negative");
   PARTHENON_REQUIRE(kinetic_jet_temperature_ >= 0,
                     "Kinetic jet temperature must be non-negative");
+
+  // Compute the internal energy ceiling from the temperature ceiling
+  const Real tceil = pin->GetOrAddReal("problem/cluster/agn_feedback", "Tceil",
+                                       std::numeric_limits<Real>::infinity());
+  eceil_ = tceil / mbar_gm1_over_kb;
 
   // Add user history output variable for AGN power
   auto hst_vars = hydro_pkg->Param<parthenon::HstVar_list>(parthenon::hist_param_key);
@@ -261,15 +269,18 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
 
   // Velocity of added gas
   const Real jet_velocity = kinetic_jet_velocity_;
-#ifndef NDEBUG
   const Real jet_specific_internal_e = kinetic_jet_e_;
-#endif
 
   // Amount of momentum density ( density * velocity) to dump in each cell
   const Real jet_momentum = jet_density * jet_velocity;
 
   // Amount of total energy to dump in each cell
   const Real jet_feedback = kinetic_fraction_ * power * kinetic_scaling_factor * beta_dt;
+
+  const Real vceil = vceil_;
+  const Real vceil2 = SQR(vceil);
+  const Real eceil = eceil_;
+  const Real gm1 = (hydro_pkg->Param<Real>("AdiabaticIndex") - 1.0);
   ////////////////////////////////////////////////////////////////////////////////
 
   const parthenon::Real time = tm.time;
@@ -278,7 +289,7 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
       hydro_pkg->Param<JetCoordsFactory>("jet_coords_factory");
   const JetCoords jet_coords = jet_coords_factory.CreateJetCoords(time);
 
-  // Constant volumetric heating
+  // Appy kinietic jet and thermal feedback
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "HydroAGNFeedback::FeedbackSrcTerm",
       parthenon::DevExecSpace(), 0, cons_pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s,
@@ -321,17 +332,15 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
 
             const Real sign_jet = (h > 0) ? 1 : -1; // Above or below jet-disk
 
-        ///////////////////////////////////////////////////////////////////
-        //  We add the kinetic jet with a fixed jet velocity and specific
-        //  internal energy/temperature of the added gas. The density,
-        //  momentum, and total energy added depend on the triggered power.
-        ///////////////////////////////////////////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            //  We add the kinetic jet with a fixed jet velocity and specific
+            //  internal energy/temperature of the added gas. The density,
+            //  momentum, and total energy added depend on the triggered power.
+            ///////////////////////////////////////////////////////////////////
 
-#ifndef NDEBUG
             eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
             const Real old_specific_internal_e =
                 prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
-#endif
 
             cons(IDN, k, j, i) += jet_density;
             cons(IM1, k, j, i) += jet_momentum * sign_jet * jet_axis_x;
@@ -339,20 +348,43 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
             cons(IM3, k, j, i) += jet_momentum * sign_jet * jet_axis_z;
             cons(IEN, k, j, i) += jet_feedback;
 
-#ifndef NDEBUG
             eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
             const Real new_specific_internal_e =
                 prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
-            PARTHENON_DEBUG_REQUIRE(
+            PARTHENON_REQUIRE(
                 new_specific_internal_e > jet_specific_internal_e ||
                     new_specific_internal_e > old_specific_internal_e,
                 "Kinetic injection leads to temperature below jet and existing gas");
-#endif
+          }
+
+          // Apply velocity ceiling
+          const Real v2 =
+              SQR(prim(IV1, k, j, i)) + SQR(prim(IV2, k, j, i)) + SQR(prim(IV3, k, j, i));
+          if (v2 > vceil2) {
+            // Fix the velocity to the velocity ceiling
+            const Real v = sqrt(v2);
+            cons(IM1, k, j, i) *= vceil / v;
+            cons(IM2, k, j, i) *= vceil / v;
+            cons(IM3, k, j, i) *= vceil / v;
+            prim(IV1, k, j, i) *= vceil / v;
+            prim(IV2, k, j, i) *= vceil / v;
+            prim(IV3, k, j, i) *= vceil / v;
+
+            // Remove kinetic energy
+            cons(IEN, k, j, i) -= 0.5 * prim(IDN, k, j, i) * (v2 - vceil2);
+          }
+
+          // Apply  internal energy ceiling as a pressure ceiling
+          const Real internal_e = prim(IPR, k, j, i) / (gm1 * prim(IDN, k, j, i));
+          if (internal_e > eceil) {
+            cons(IEN, k, j, i) -= prim(IDN, k, j, i) * (internal_e - eceil);
+            prim(IPR, k, j, i) = gm1 * prim(IDN, k, j, i) * eceil;
           }
         }
+
         eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
-        PARTHENON_DEBUG_REQUIRE(prim(IPR, k, j, i) > 0,
-                                "Kinetic injection leads to negative pressure");
+        PARTHENON_REQUIRE(prim(IPR, k, j, i) > 0,
+                          "Kinetic injection leads to negative pressure");
       });
 
   // Apply magnetic tower feedback

--- a/src/pgen/cluster/agn_feedback.hpp
+++ b/src/pgen/cluster/agn_feedback.hpp
@@ -31,6 +31,9 @@ class AGNFeedback {
   // Efficiency converting mass to energy
   const parthenon::Real efficiency_;
 
+  // Velocity and temperature ceilings
+  parthenon::Real vceil_, eceil_;
+
   // Thermal Heating Parameters
   const parthenon::Real thermal_radius_;
 

--- a/src/pgen/cluster/agn_triggering.cpp
+++ b/src/pgen/cluster/agn_triggering.cpp
@@ -7,6 +7,7 @@
 //  \brief  Class for computing AGN triggering from Bondi-like and cold gas accretion
 
 #include <cmath>
+#include <fstream> // for ofstream
 #include <limits>
 
 // Parthenon headers

--- a/src/pgen/pgen.hpp
+++ b/src/pgen/pgen.hpp
@@ -98,7 +98,7 @@ using namespace parthenon::driver::prelude;
 
 void ProblemInitPackageData(ParameterInput *pin, parthenon::StateDescriptor *pkg);
 void InitUserMeshData(ParameterInput *pin);
-void ProblemGenerator(MeshBlock *pmb, parthenon::ParameterInput *pin);
+void ProblemGenerator(Mesh *pmesh, ParameterInput *pin, MeshData<Real> *md);
 void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin);
 void ClusterSrcTerm(MeshData<Real> *md, const parthenon::SimTime &tm, const Real beta_dt);
 parthenon::Real ClusterEstimateTimestep(MeshData<Real> *md);

--- a/src/pgen/turbulence.cpp
+++ b/src/pgen/turbulence.cpp
@@ -449,7 +449,6 @@ void Driving(MeshData<Real> *md, const parthenon::SimTime &tm, const Real dt) {
 void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin) {
   auto hydro_pkg = pmb->packages.Get("Hydro");
 
-
   // Store (common) acceleration field in spectral space
   auto few_modes_ft = hydro_pkg->Param<FewModesFT>("turbulence/few_modes_ft");
   auto var_hat = few_modes_ft.GetVarHat();

--- a/src/utils/few_modes_ft.cpp
+++ b/src/utils/few_modes_ft.cpp
@@ -50,9 +50,9 @@ FewModesFT::FewModesFT(parthenon::ParameterInput *pin, parthenon::StateDescripto
   // lambda cannot live in the constructor of an object.
   auto k_vec_host = k_vec.GetHostMirrorAndCopy();
   for (int i = 0; i < num_modes; i++) {
-    PARTHENON_REQUIRE(std::abs(k_vec(0, i)) <= gnx1 / 2, "k_vec x1 mode too large");
-    PARTHENON_REQUIRE(std::abs(k_vec(1, i)) <= gnx2 / 2, "k_vec x2 mode too large");
-    PARTHENON_REQUIRE(std::abs(k_vec(2, i)) <= gnx3 / 2, "k_vec x3 mode too large");
+    PARTHENON_REQUIRE(std::abs(k_vec_host(0, i)) <= gnx1 / 2, "k_vec x1 mode too large");
+    PARTHENON_REQUIRE(std::abs(k_vec_host(1, i)) <= gnx2 / 2, "k_vec x2 mode too large");
+    PARTHENON_REQUIRE(std::abs(k_vec_host(2, i)) <= gnx3 / 2, "k_vec x3 mode too large");
   }
 
   const auto nx1 = pin->GetInteger("parthenon/meshblock", "nx1");

--- a/src/utils/few_modes_ft.cpp
+++ b/src/utils/few_modes_ft.cpp
@@ -1,0 +1,332 @@
+//========================================================================================
+// AthenaPK - a performance portable block structured AMR astrophysical MHD code.
+// Copyright (c) 2023, Athena-Parthenon Collaboration. All rights reserved.
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//========================================================================================
+//! \file few_modes_ft.cpp
+//  \brief Helper functions for an inverse (explicit complex to real) FT
+
+// C++ headers
+#include <utility>
+
+// Parthenon headers
+#include "basic_types.hpp"
+#include "config.hpp"
+#include "kokkos_abstraction.hpp"
+#include "mesh/domain.hpp"
+#include "mesh/meshblock_pack.hpp"
+
+// AthenaPK headers
+#include "../main.hpp"
+#include "few_modes_ft.hpp"
+#include "utils/error_checking.hpp"
+
+namespace utils::few_modes_ft {
+using Complex = Kokkos::complex<parthenon::Real>;
+using parthenon::IndexRange;
+using parthenon::Metadata;
+
+FewModesFT::FewModesFT(parthenon::ParameterInput *pin, parthenon::StateDescriptor *pkg,
+                       std::string prefix, int num_modes, ParArray2D<Real> k_vec,
+                       Real k_peak, Real sol_weight, Real t_corr)
+    : prefix_(prefix), num_modes_(num_modes), k_vec_(k_vec), k_peak_(k_peak),
+      t_corr_(t_corr), dist_(-1.0, 1.0) {
+
+  if ((num_modes > 100) && (parthenon::Globals::my_rank == 0)) {
+    std::cout << "### WARNING using more than 100 explicit modes will significantly "
+              << "increase the runtime." << std::endl
+              << "If many modes are required in the transform field consider using "
+              << "the driving mechanism based on full FFTs." << std::endl;
+  }
+  const auto nx1 = pin->GetInteger("parthenon/meshblock", "nx1");
+  const auto nx2 = pin->GetInteger("parthenon/meshblock", "nx2");
+  const auto nx3 = pin->GetInteger("parthenon/meshblock", "nx3");
+  auto m = Metadata({Metadata::None, Metadata::Derived, Metadata::OneCopy},
+                    std::vector<int>({2, num_modes, nx1}), prefix + "_phases_i");
+  pkg->AddField(prefix + "_phases_i", m);
+  m = Metadata({Metadata::None, Metadata::Derived, Metadata::OneCopy},
+               std::vector<int>({2, num_modes, nx2}), prefix + "_phases_j");
+  pkg->AddField(prefix + "_phases_j", m);
+  m = Metadata({Metadata::None, Metadata::Derived, Metadata::OneCopy},
+               std::vector<int>({2, num_modes, nx3}), prefix + "_phases_k");
+  pkg->AddField(prefix + "_phases_k", m);
+
+  // Variable (e.g., acceleration field for turbulence driver) in Fourier space using
+  // complex to real transform.
+  var_hat_ = ParArray2D<Complex>(prefix + "_var_hat", 3, num_modes);
+  var_hat_new_ = ParArray2D<Complex>(prefix + "_var_hat_new", 3, num_modes);
+
+  PARTHENON_REQUIRE((sol_weight == -1.0) || (sol_weight >= 0.0 && sol_weight <= 1.0),
+                    "sol_weight for projection in few modes fft module needs to be "
+                    "between 0.0 and 1.0 or set to -1.0 (to disable projection).")
+  sol_weight_ = sol_weight;
+
+  random_num_ = Kokkos::View<Real ***, Kokkos::LayoutRight, parthenon::DevMemSpace>(
+      "random_num", 3, num_modes, 2);
+  random_num_host_ = Kokkos::create_mirror_view(random_num_);
+}
+
+void FewModesFT::SetPhases(MeshBlock *pmb, ParameterInput *pin) {
+  auto pm = pmb->pmy_mesh;
+  auto hydro_pkg = pmb->packages.Get("Hydro");
+
+  // The following restriction could technically be lifted if the turbulence driver is
+  // directly embedded in the hydro driver rather than a user defined source as well as
+  // fixing the pack_size=-1 when using the Mesh- (not MeshBlock-)based problem generator.
+  // The restriction stems from requiring a collective MPI comm to normalize the
+  // acceleration and magnetic field, respectively. Note, that the restriction does not
+  // apply here, but for the ProblemGenerator() and Driving() function below. The check is
+  // just added here for convenience as this function is called during problem
+  // initializtion. From my (pgrete) point of view, it's currently cleaner to keep things
+  // separate and not touch the main driver at the expense of using one pack per rank --
+  // which is typically fastest on devices anyway.
+  const auto pack_size = pin->GetInteger("parthenon/mesh", "pack_size");
+  PARTHENON_REQUIRE_THROWS(pack_size == -1,
+                           "Few modes FT currently needs parthenon/mesh/pack_size=-1 "
+                           "to work because of global reductions.")
+
+  auto Lx = pm->mesh_size.x1max - pm->mesh_size.x1min;
+  auto Ly = pm->mesh_size.x2max - pm->mesh_size.x2min;
+  auto Lz = pm->mesh_size.x3max - pm->mesh_size.x3min;
+  // should also be easily fixed, just need to double check transforms and volume
+  // weighting everywhere
+  if ((Lx != 1.0) || (Ly != 1.0) || (Lz != 1.0)) {
+    std::stringstream msg;
+    msg << "### FATAL ERROR in turbulence driver" << std::endl
+        << "Only domain sizes with edge lengths of 1 are supported." << std::endl;
+    throw std::runtime_error(msg.str().c_str());
+  }
+
+  auto gnx1 = pm->mesh_size.nx1;
+  auto gnx2 = pm->mesh_size.nx2;
+  auto gnx3 = pm->mesh_size.nx3;
+  // as above, this restriction should/could be easily lifted
+  if ((gnx1 != gnx2) || (gnx2 != gnx3)) {
+    std::stringstream msg;
+    msg << "### FATAL ERROR in turbulence driver" << std::endl
+        << "Only cubic mesh sizes are supported." << std::endl;
+    throw std::runtime_error(msg.str().c_str());
+  }
+
+  const auto nx1 = pmb->block_size.nx1;
+  const auto nx2 = pmb->block_size.nx2;
+  const auto nx3 = pmb->block_size.nx3;
+
+  const auto gis = pmb->loc.lx1 * pmb->block_size.nx1;
+  const auto gjs = pmb->loc.lx2 * pmb->block_size.nx2;
+  const auto gks = pmb->loc.lx3 * pmb->block_size.nx3;
+
+  // make local ref to capure in lambda
+  const auto num_modes = num_modes_;
+  auto &k_vec = k_vec_;
+
+  Complex I(0.0, 1.0);
+
+  auto &base = pmb->meshblock_data.Get();
+  auto &phases_i = base->Get(prefix_ + "_phases_i").data;
+  auto &phases_j = base->Get(prefix_ + "_phases_j").data;
+  auto &phases_k = base->Get(prefix_ + "_phases_k").data;
+
+  pmb->par_for(
+      "FMFT: calc phases_i", 0, nx1 - 1, KOKKOS_LAMBDA(int i) {
+        Real gi = static_cast<Real>(i + gis);
+        Real w_kx;
+        Complex phase;
+
+        for (int m = 0; m < num_modes; m++) {
+          w_kx = k_vec(0, m) * 2. * M_PI / static_cast<Real>(gnx1);
+          // adjust phase factor to Complex->Real IFT: u_hat*(k) = u_hat(-k)
+          if (k_vec(0, m) == 0.0) {
+            phase = 0.5 * Kokkos::exp(I * w_kx * gi);
+          } else {
+            phase = Kokkos::exp(I * w_kx * gi);
+          }
+          phases_i(i, m, 0) = phase.real();
+          phases_i(i, m, 1) = phase.imag();
+        }
+      });
+
+  pmb->par_for(
+      "FMFT: calc phases_j", 0, nx2 - 1, KOKKOS_LAMBDA(int j) {
+        Real gj = static_cast<Real>(j + gjs);
+        Real w_ky;
+        Complex phase;
+
+        for (int m = 0; m < num_modes; m++) {
+          w_ky = k_vec(1, m) * 2. * M_PI / static_cast<Real>(gnx2);
+          phase = Kokkos::exp(I * w_ky * gj);
+          phases_j(j, m, 0) = phase.real();
+          phases_j(j, m, 1) = phase.imag();
+        }
+      });
+
+  pmb->par_for(
+      "FMFT: calc phases_k", 0, nx3 - 1, KOKKOS_LAMBDA(int k) {
+        Real gk = static_cast<Real>(k + gks);
+        Real w_kz;
+        Complex phase;
+
+        for (int m = 0; m < num_modes; m++) {
+          w_kz = k_vec(2, m) * 2. * M_PI / static_cast<Real>(gnx3);
+          phase = Kokkos::exp(I * w_kz * gk);
+          phases_k(k, m, 0) = phase.real();
+          phases_k(k, m, 1) = phase.imag();
+        }
+      });
+}
+
+void FewModesFT::Generate(MeshData<Real> *md, const Real dt,
+                          const std::string &var_name) {
+  auto pmb = md->GetBlockData(0)->GetBlockPointer();
+
+  const auto num_modes = num_modes_;
+
+  Complex I(0.0, 1.0);
+  auto &random_num = random_num_;
+
+  // get a set of random numbers from the CPU so that they are deterministic
+  // when run on GPUs
+  Real v1, v2, v_sqr;
+  for (int n = 0; n < 3; n++)
+    for (int m = 0; m < num_modes; m++) {
+      do {
+        v1 = dist_(rng_);
+        v2 = dist_(rng_);
+        v_sqr = v1 * v1 + v2 * v2;
+      } while (v_sqr >= 1.0 || v_sqr == 0.0);
+
+      random_num_host_(n, m, 0) = v1;
+      random_num_host_(n, m, 1) = v2;
+    }
+  Kokkos::deep_copy(random_num, random_num_host_);
+
+  // make local ref to capure in lambda
+  auto &k_vec = k_vec_;
+  auto &var_hat = var_hat_;
+  auto &var_hat_new = var_hat_new_;
+
+  const auto kpeak = k_peak_;
+
+  // generate new power spectrum (injection)
+  pmb->par_for(
+      "FMFT: new power spec", 0, 2, 0, num_modes - 1,
+      KOKKOS_LAMBDA(const int n, const int m) {
+        Real kmag, tmp, norm, v_sqr;
+
+        Real kx = k_vec(0, m);
+        Real ky = k_vec(1, m);
+        Real kz = k_vec(2, m);
+
+        kmag = std::sqrt(kx * kx + ky * ky + kz * kz);
+
+        var_hat_new(n, m) = Complex(0., 0.);
+
+        tmp = std::pow(kmag / kpeak, 2.) * (2. - std::pow(kmag / kpeak, 2.));
+        if (tmp < 0.) tmp = 0.;
+        v_sqr = SQR(random_num(n, m, 0)) + SQR(random_num(n, m, 1));
+        norm = std::sqrt(-2.0 * std::log(v_sqr) / v_sqr);
+
+        var_hat_new(n, m) =
+            Complex(tmp * norm * random_num(n, m, 0), tmp * norm * random_num(n, m, 1));
+      });
+
+  // enforce symmetry of complex to real transform
+  pmb->par_for(
+      "forcing: enforce symmetry", 0, 2, 0, num_modes - 1,
+      KOKKOS_LAMBDA(const int n, const int m) {
+        if (k_vec(0, m) == 0.) {
+          for (int m2 = 0; m2 < m; m2++) {
+            if (k_vec(1, m) == -k_vec(1, m2) && k_vec(2, m) == -k_vec(2, m2))
+              var_hat_new(n, m) =
+                  Complex(var_hat_new(n, m2).real(), -var_hat_new(n, m2).imag());
+          }
+        }
+      });
+
+  const auto sol_weight = sol_weight_;
+  if (sol_weight_ >= 0.0) {
+    // project
+    pmb->par_for(
+        "forcing: projection", 0, num_modes - 1, KOKKOS_LAMBDA(const int m) {
+          Real kmag;
+
+          Real kx = k_vec(0, m);
+          Real ky = k_vec(1, m);
+          Real kz = k_vec(2, m);
+
+          kmag = std::sqrt(kx * kx + ky * ky + kz * kz);
+
+          // setting kmag to 1 as a "continue" doesn't work within the parallel_for
+          // construct and it doesn't affect anything (there should never be power in the
+          // k=0 mode)
+          if (kmag == 0.) kmag = 1.;
+
+          // make it a unit vector
+          kx /= kmag;
+          ky /= kmag;
+          kz /= kmag;
+
+          Complex dot(var_hat_new(0, m).real() * kx + var_hat_new(1, m).real() * ky +
+                          var_hat_new(2, m).real() * kz,
+                      var_hat_new(0, m).imag() * kx + var_hat_new(1, m).imag() * ky +
+                          var_hat_new(2, m).imag() * kz);
+
+          var_hat_new(0, m) = Complex(var_hat_new(0, m).real() * sol_weight +
+                                          (1. - 2. * sol_weight) * dot.real() * kx,
+                                      var_hat_new(0, m).imag() * sol_weight +
+                                          (1. - 2. * sol_weight) * dot.imag() * kx);
+          var_hat_new(1, m) = Complex(var_hat_new(1, m).real() * sol_weight +
+                                          (1. - 2. * sol_weight) * dot.real() * ky,
+                                      var_hat_new(1, m).imag() * sol_weight +
+                                          (1. - 2. * sol_weight) * dot.imag() * ky);
+          var_hat_new(2, m) = Complex(var_hat_new(2, m).real() * sol_weight +
+                                          (1. - 2. * sol_weight) * dot.real() * kz,
+                                      var_hat_new(2, m).imag() * sol_weight +
+                                          (1. - 2. * sol_weight) * dot.imag() * kz);
+        });
+  }
+
+  // evolve
+  const auto t_corr = t_corr_;
+  Real c_drift = std::exp(-dt / t_corr);
+  Real c_diff = std::sqrt(1.0 - c_drift * c_drift);
+
+  pmb->par_for(
+      "FMFT: evolve spec", 0, 2, 0, num_modes - 1,
+      KOKKOS_LAMBDA(const int n, const int m) {
+        var_hat(n, m) =
+            Complex(var_hat(n, m).real() * c_drift + var_hat_new(n, m).real() * c_diff,
+                    var_hat(n, m).imag() * c_drift + var_hat_new(n, m).imag() * c_diff);
+      });
+
+  IndexRange ib = md->GetBlockData(0)->GetBoundsI(IndexDomain::interior);
+  IndexRange jb = md->GetBlockData(0)->GetBoundsJ(IndexDomain::interior);
+  IndexRange kb = md->GetBlockData(0)->GetBoundsK(IndexDomain::interior);
+  auto var_pack = md->PackVariables(std::vector<std::string>{var_name});
+  auto phases_i = md->PackVariables(std::vector<std::string>{prefix_ + "_phases_i"});
+  auto phases_j = md->PackVariables(std::vector<std::string>{prefix_ + "_phases_j"});
+  auto phases_k = md->PackVariables(std::vector<std::string>{prefix_ + "_phases_k"});
+
+  // implictly assuming cubic box of size L=1
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "FMFT: Inverse FT", parthenon::DevExecSpace(), 0,
+      md->NumBlocks() - 1, 0, 2, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int b, const int n, const int k, const int j, const int i) {
+        Complex phase, phase_i, phase_j, phase_k;
+        var_pack(b, n, k, j, i) = 0.0;
+
+        for (int m = 0; m < num_modes; m++) {
+          phase_i =
+              Complex(phases_i(b, 0, i - ib.s, m, 0), phases_i(b, 0, i - ib.s, m, 1));
+          phase_j =
+              Complex(phases_j(b, 0, j - jb.s, m, 0), phases_j(b, 0, j - jb.s, m, 1));
+          phase_k =
+              Complex(phases_k(b, 0, k - kb.s, m, 0), phases_k(b, 0, k - kb.s, m, 1));
+          phase = phase_i * phase_j * phase_k;
+          var_pack(b, n, k, j, i) += 2. * (var_hat(n, m).real() * phase.real() -
+                                           var_hat(n, m).imag() * phase.imag());
+        }
+      });
+}
+} // namespace utils::few_modes_ft

--- a/src/utils/few_modes_ft.cpp
+++ b/src/utils/few_modes_ft.cpp
@@ -44,12 +44,14 @@ FewModesFT::FewModesFT(parthenon::ParameterInput *pin, parthenon::StateDescripto
   const auto gnx1 = pin->GetInteger("parthenon/mesh", "nx1");
   const auto gnx2 = pin->GetInteger("parthenon/mesh", "nx2");
   const auto gnx3 = pin->GetInteger("parthenon/mesh", "nx3");
-  Kokkos::parallel_for(
-      "FMFT: Check k_vec", num_modes, KOKKOS_LAMBDA(const int i) {
-        PARTHENON_REQUIRE(std::abs(k_vec_(0, i)) <= gnx1 / 2, "k_vec x1 mode too large");
-        PARTHENON_REQUIRE(std::abs(k_vec_(1, i)) <= gnx2 / 2, "k_vec x2 mode too large");
-        PARTHENON_REQUIRE(std::abs(k_vec_(2, i)) <= gnx3 / 2, "k_vec x3 mode too large");
-      });
+  // Need to make this comparison on the host as (for some reason) an extended cuda device
+  // lambda cannot live in the constructor of an object.
+  auto k_vec_host = k_vec.GetHostMirrorAndCopy();
+  for (int i = 0; i < num_modes; i++) {
+    PARTHENON_REQUIRE(std::abs(k_vec(0, i)) <= gnx1 / 2, "k_vec x1 mode too large");
+    PARTHENON_REQUIRE(std::abs(k_vec(1, i)) <= gnx2 / 2, "k_vec x2 mode too large");
+    PARTHENON_REQUIRE(std::abs(k_vec(2, i)) <= gnx3 / 2, "k_vec x3 mode too large");
+  }
 
   const auto nx1 = pin->GetInteger("parthenon/meshblock", "nx1");
   const auto nx2 = pin->GetInteger("parthenon/meshblock", "nx2");

--- a/src/utils/few_modes_ft.cpp
+++ b/src/utils/few_modes_ft.cpp
@@ -342,4 +342,60 @@ void FewModesFT::Generate(MeshData<Real> *md, const Real dt,
         }
       });
 }
+
+// Creates a random set of wave vectors with k_mag within k_peak/2 and 2*k_peak
+ParArray2D<Real> MakeRandomModes(const int num_modes, const Real k_peak,
+                                 uint32_t rseed = 31224) {
+  auto k_vec = parthenon::ParArray2D<Real>("k_vec", 3, num_modes);
+  auto k_vec_h = Kokkos::create_mirror_view_and_copy(parthenon::HostMemSpace(), k_vec);
+
+  const int k_low = std::floor(k_peak / 2);
+  const int k_high = std::ceil(2 * k_peak);
+
+  std::mt19937 rng;
+  rng.seed(rseed);
+  std::uniform_int_distribution<> dist(-k_high, k_high);
+
+  int n_mode = 0;
+  int n_attempt = 0;
+  constexpr int max_attempts = 1000000;
+  Real kx1, kx2, kx3, k_mag, ampl;
+  bool mode_exists = false;
+  while (n_mode < num_modes && n_attempt < max_attempts) {
+    n_attempt += 1;
+
+    kx1 = dist(rng);
+    kx2 = dist(rng);
+    kx3 = dist(rng);
+    k_mag = std::sqrt(SQR(kx1) + SQR(kx2) + SQR(kx3));
+
+    // Expected amplitude of the spectral function. If this is changed, it also needs to
+    // be changed in the FMFT class (or abstracted).
+    ampl = SQR(k_mag / k_peak) * (2.0 - SQR(k_mag / k_peak));
+
+    // Check is mode was already picked by chance
+    mode_exists = false;
+    for (int n_mode_exsist = 0; n_mode_exsist < n_mode; n_mode_exsist++) {
+      if (k_vec_h(0, n_mode_exsist) == kx1 && k_vec_h(1, n_mode_exsist) == kx2 &&
+          k_vec_h(2, n_mode_exsist) == kx3) {
+        mode_exists = true;
+      }
+    }
+
+    // kx1 < 0.0 because we use a explicit symmetric Complex to Real transform
+    if (ampl < 0 || k_mag < k_low || k_mag > k_high || mode_exists || kx1 < 0.0) {
+      continue;
+    }
+    k_vec_h(0, n_mode) = kx1;
+    k_vec_h(1, n_mode) = kx2;
+    k_vec_h(2, n_mode) = kx3;
+    n_mode++;
+  }
+  PARTHENON_REQUIRE_THROWS(
+      n_attempt < max_attempts,
+      "Cluster init did not succeed in calculating perturbation modes.")
+  Kokkos::deep_copy(k_vec, k_vec_h);
+
+  return k_vec;
+}
 } // namespace utils::few_modes_ft

--- a/src/utils/few_modes_ft.hpp
+++ b/src/utils/few_modes_ft.hpp
@@ -37,14 +37,15 @@ class FewModesFT {
   Kokkos::View<Real ***, Kokkos::LayoutRight, parthenon::HostMemSpace> random_num_host_;
   std::mt19937 rng_;
   std::uniform_real_distribution<> dist_;
-  Real sol_weight_; // power in solenoidal modes for projection. Set to negative to
-                    // disable projection
-  Real t_corr_;     // correlation time for evolution of Ornstein-Uhlenbeck process
+  Real sol_weight_;  // power in solenoidal modes for projection. Set to negative to
+                     // disable projection
+  Real t_corr_;      // correlation time for evolution of Ornstein-Uhlenbeck process
+  bool fill_ghosts_; // if the inverse transform should also fill ghost zones
 
  public:
   FewModesFT(parthenon::ParameterInput *pin, parthenon::StateDescriptor *pkg,
              std::string prefix, int num_modes, ParArray2D<Real> k_vec, Real k_peak,
-             Real sol_weight, Real t_corr, uint32_t rseed);
+             Real sol_weight, Real t_corr, uint32_t rseed, bool fill_ghosts = false);
 
   ParArray2D<Complex> GetVarHat() { return var_hat_; }
   int GetNumModes() { return num_modes_; }

--- a/src/utils/few_modes_ft.hpp
+++ b/src/utils/few_modes_ft.hpp
@@ -1,0 +1,50 @@
+
+//========================================================================================
+// AthenaPK - a performance portable block structured AMR astrophysical MHD code.
+// Copyright (c) 2023, Athena-Parthenon Collaboration. All rights reserved.
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//========================================================================================
+//! \file few_modes_ft.hpp
+//  \brief Helper functions for an inverse (explicit complex to real) FT
+
+// Parthenon headers
+#include "basic_types.hpp"
+#include "config.hpp"
+#include "kokkos_abstraction.hpp"
+
+// AthenaPK headers
+#include "../main.hpp"
+#include "mesh/domain.hpp"
+
+namespace utils::few_modes_ft {
+using Complex = Kokkos::complex<parthenon::Real>;
+using parthenon::IndexRange;
+
+template <typename TPack, typename THat>
+void InverseFT(const TPack &out_pack, const TPack &phases_i, const TPack &phases_j,
+               const TPack &phases_k, const THat &in_hat, const IndexRange &ib,
+               const IndexRange &jb, const IndexRange &kb, const int num_blocks,
+               const int num_modes) {
+  // implictly assuming cubic box of size L=1
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "Inverse FT", parthenon::DevExecSpace(), 0, num_blocks - 1, 0,
+      2, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int b, const int n, const int k, const int j, const int i) {
+        Complex phase, phase_i, phase_j, phase_k;
+        out_pack(b, n, k, j, i) = 0.0;
+
+        for (int m = 0; m < num_modes; m++) {
+          phase_i =
+              Complex(phases_i(b, 0, i - ib.s, m, 0), phases_i(b, 0, i - ib.s, m, 1));
+          phase_j =
+              Complex(phases_j(b, 0, j - jb.s, m, 0), phases_j(b, 0, j - jb.s, m, 1));
+          phase_k =
+              Complex(phases_k(b, 0, k - kb.s, m, 0), phases_k(b, 0, k - kb.s, m, 1));
+          phase = phase_i * phase_j * phase_k;
+          out_pack(b, n, k, j, i) += 2. * (in_hat(n, m).real() * phase.real() -
+                                           in_hat(n, m).imag() * phase.imag());
+        }
+      });
+}
+} // namespace utils::few_modes_ft

--- a/src/utils/few_modes_ft.hpp
+++ b/src/utils/few_modes_ft.hpp
@@ -11,15 +11,32 @@
 // Parthenon headers
 #include "basic_types.hpp"
 #include "config.hpp"
-#include "kokkos_abstraction.hpp"
+#include <parthenon/package.hpp>
 
 // AthenaPK headers
 #include "../main.hpp"
 #include "mesh/domain.hpp"
 
 namespace utils::few_modes_ft {
-using Complex = Kokkos::complex<parthenon::Real>;
+using parthenon::Real;
+using Complex = Kokkos::complex<Real>;
 using parthenon::IndexRange;
+using parthenon::ParArray2D;
+
+class FewModesFT {
+ private:
+  int num_modes_;
+  std::string prefix_;
+  ParArray2D<Complex> var_hat_, var_hat_new_;
+  ParArray2D<Real> k_vec_;
+
+ public:
+  FewModesFT(parthenon::ParameterInput *pin, parthenon::StateDescriptor *pkg,
+             std::string prefix, int num_modes, ParArray2D<Real> k_vec);
+
+  ParArray2D<Complex> GetVarHat() { return var_hat_ }
+  void SetVarHat(ParArray2D<Complex> var_hat) { var_hat_ = var_hat }
+};
 
 template <typename TPack, typename THat>
 void InverseFT(const TPack &out_pack, const TPack &phases_i, const TPack &phases_j,

--- a/src/utils/few_modes_ft.hpp
+++ b/src/utils/few_modes_ft.hpp
@@ -44,7 +44,7 @@ class FewModesFT {
  public:
   FewModesFT(parthenon::ParameterInput *pin, parthenon::StateDescriptor *pkg,
              std::string prefix, int num_modes, ParArray2D<Real> k_vec, Real k_peak,
-             Real sol_weight, Real t_corr);
+             Real sol_weight, Real t_corr, uint32_t rseed);
 
   ParArray2D<Complex> GetVarHat() { return var_hat_; }
   int GetNumModes() { return num_modes_; }
@@ -52,7 +52,6 @@ class FewModesFT {
   void Generate(MeshData<Real> *md, const Real dt, const std::string &var_name);
   void RestoreRNG(std::istringstream &iss) { iss >> rng_; }
   void RestoreDist(std::istringstream &iss) { iss >> dist_; }
-  void SeedRNG(uint32_t rseed) { rng_.seed(rseed); }
   std::string GetRNGState() {
     std::ostringstream oss;
     oss << rng_;

--- a/src/utils/few_modes_ft.hpp
+++ b/src/utils/few_modes_ft.hpp
@@ -64,4 +64,7 @@ class FewModesFT {
   }
 };
 
+// Creates a random set of wave vectors with k_mag within k_peak/2 and 2*k_peak
+ParArray2D<Real> MakeRandomModes(const int num_modes, const Real k_peak, uint32_t rseed);
+
 } // namespace utils::few_modes_ft

--- a/tst/regression/CMakeLists.txt
+++ b/tst/regression/CMakeLists.txt
@@ -35,7 +35,7 @@ setup_test_serial("performance" "--driver ${PROJECT_BINARY_DIR}/bin/athenaPK \
   --driver_input ${PROJECT_SOURCE_DIR}/inputs/linear_wave3d.in --num_steps 21" "performance")
 
 setup_test_both("cluster_hse" "--driver ${PROJECT_BINARY_DIR}/bin/athenaPK \
-  --driver_input ${PROJECT_SOURCE_DIR}/inputs/cluster/hse.in --num_steps 1" "convergence")
+  --driver_input ${PROJECT_SOURCE_DIR}/inputs/cluster/hse.in --num_steps 2" "convergence")
 
 setup_test_serial("cluster_tabular_cooling" "--driver ${PROJECT_BINARY_DIR}/bin/athenaPK \
   --driver_input ${PROJECT_SOURCE_DIR}/inputs/cluster/cooling.in --num_steps 11" "convergence")

--- a/tst/regression/test_suites/cluster_hse/cluster_hse.py
+++ b/tst/regression/test_suites/cluster_hse/cluster_hse.py
@@ -39,7 +39,10 @@ class TestCase(utils.test_case.TestCaseAbs):
         unyt.define_unit("code_mass", (1e14, "Msun"))
         unyt.define_unit("code_time", (1, "Gyr"))
         unyt.define_unit("code_velocity", (1, "code_length/code_time"))
-        unyt.define_unit("code_magnetic", (np.sqrt(4*np.pi), "(code_mass/code_length)**0.5/code_time"))
+        unyt.define_unit(
+            "code_magnetic",
+            (np.sqrt(4 * np.pi), "(code_mass/code_length)**0.5/code_time"),
+        )
         self.code_length = unyt.unyt_quantity(1, "code_length")
         self.code_mass = unyt.unyt_quantity(1, "code_mass")
         self.code_time = unyt.unyt_quantity(1, "code_time")

--- a/tst/regression/test_suites/cluster_hse/cluster_hse.py
+++ b/tst/regression/test_suites/cluster_hse/cluster_hse.py
@@ -93,6 +93,12 @@ class TestCase(utils.test_case.TestCaseAbs):
         self.norm_tol = 1e-3
 
         self.sigma_v = unyt.unyt_quantity(75.0, "km/s")
+        char_v_lengthscale = unyt.unyt_quantity(100.0, "kpc")
+        # Note that the box scale is set in the input file directly (-0.1 to 0.1),
+        # so if the input file changes, the following line should change, too.
+        Lbox = 0.2 * self.code_length
+        self.k_peak_v = Lbox / char_v_lengthscale
+
         self.sigma_B = unyt.unyt_quantity(1e-8, "G")
 
     def Prepare(self, parameters, step):
@@ -144,6 +150,7 @@ class TestCase(utils.test_case.TestCaseAbs):
             f"problem/cluster/hydrostatic_equilibrium/rho_fix={self.rho_fix.in_units('code_mass/code_length**3').v}",
             f"problem/cluster/hydrostatic_equilibrium/r_sampling={self.R_sampling}",
             f"problem/cluster/init_perturb/sigma_v={0.0 if step == 2 else self.sigma_v.in_units('code_length/code_time').v}",
+            f"problem/cluster/init_perturb/k_peak_v={0.0 if step == 2 else self.k_peak_v.v}",
             f"problem/cluster/init_perturb/sigma_B={0.0 if step == 2 else self.sigma_B.in_units('(code_mass/code_length)**0.5/code_time').v}",
             f"parthenon/output2/id={'prim' if step == 2 else 'prim_perturb'}",
             f"parthenon/time/nlim={-1 if step == 2 else 1}",

--- a/tst/regression/test_suites/cluster_tabular_cooling/cluster_tabular_cooling.py
+++ b/tst/regression/test_suites/cluster_tabular_cooling/cluster_tabular_cooling.py
@@ -36,7 +36,6 @@ sys.dont_write_bytecode = True
 
 class TestCase(utils.test_case.TestCaseAbs):
     def __init__(self):
-
         # Define cluster parameters
         # Setup units
         unyt.define_unit("code_length", (1, "Mpc"))
@@ -322,10 +321,10 @@ class TestCase(utils.test_case.TestCaseAbs):
             }
 
             rho = unyt.unyt_array(
-                prim[:, prim_col_dict["density"]], "code_mass*code_length**-3"
+                prim[prim_col_dict["density"], :], "code_mass*code_length**-3"
             )
             pres = unyt.unyt_array(
-                prim[:, prim_col_dict["pressure"]],
+                prim[prim_col_dict["pressure"], :],
                 "code_mass*code_length**-1*code_time**-2",
             )
 


### PR DESCRIPTION
From the docs:

> Initial perturbations for both the velocity field and the magnetic field are
> supported.
> 
> *Note* that these intial perturbation are currently incompatible with
> other initial conditions that modify the velocity or magnetic field, e.g.,
> an initial magnetic dipole or a uniform field.
> This restriction could be lifted if required/desired but the normalization
> of the fields would need to be adjusted.
> 
> In general, the perturbations will be seeded by an inverse parabolic
> spectral profile centered on a peak wavenumber (in normalized units, i.e.,
> `k_peak = 2` mean half the box size) with a finite number of modes (default 40)
> randomly chosen between `k_peak/2` and `2*k_peak`.
> 
> Pertubations are controlled by the following parameters:
> ```
> <problem/cluster/init_perturb>
> # for the velocity field
> sigma_v = 0.0      # in code velocity; default: 0.0 (disabled)
> k_peak_v = ???     # wavenumber in normalized units where the velocity spectrum peaks. No default value.
> num_modes_v = 40   # (optional) number of wavemodes in spectral space; default: 40
> sol_weight_v = 1.0 # (optional) power in solenoidal (rotational) modes of the perturbation. Range between 0 (fully compressive) and 1.0 (default, fully solenoidal).
> rseed_v = 1        # (optional) integer seed for RNG for wavenumbers and amplitudes
> # for the magnetic field
> sigma_b = 0.0      # in code magnetic; default: 0.0 (disabled)
> k_peak_b = ???     # wavenumber in normalized units where the magnetic field spectrum peaks. No default value.
> num_modes_b = 40   # (optional) number of wavemodes in spectral space; default: 40
> rseed_b = 2        # (optional) integer seed for RNG for wavenumbers and amplitudes
> ```

In addition, this PR also 
- separates the few modes Fourier transform so that it can be used for multiple pgens
- allows turbulence sims with mesh refinement (as the driving is now calculated consistently across the mesh)