### PR TITLE
Fix Orszag Tang pgen (and add intput file)

### DIFF
--- a/inputs/orszag_tang.in
+++ b/inputs/orszag_tang.in
@@ -1,0 +1,61 @@
+# AthenaPK - a performance portable block structured AMR MHD code
+# Copyright (c) 2023, Athena Parthenon Collaboration. All rights reserved.
+# Licensed under the BSD 3-Clause License (the "LICENSE");
+
+<comment>
+problem = Orszag-Tang vortex # Orszag,S. & Tang,W., J. Fluid Mech., 90, 129 (1998)
+
+<job>
+problem_id = orszag_tang
+
+<parthenon/mesh>
+refinement = none
+nghost = 3
+
+nx1 = 256
+x1min = -0.5
+x1max = 0.5
+ix1_bc = periodic
+ox1_bc = periodic
+
+nx2 = 256
+x2min = -0.5
+x2max = 0.5
+ix2_bc = periodic
+ox2_bc = periodic
+
+nx3 = 1
+x3min = -0.5
+x3max = 0.5
+ix3_bc = periodic
+ox3_bc = periodic
+
+<parthenon/meshblock>
+nx1 = 64
+nx2 = 256
+nx3 = 1
+
+<parthenon/time>
+integrator = vl2
+cfl = 0.4
+tlim = 1.0
+nlim = -1
+perf_cycle_offset = 2 # number of inital cycles not to be included in perf calc
+
+<hydro>
+fluid = glmmhd
+eos = adiabatic
+riemann = hlld
+reconstruction = ppm
+gamma = 1.666666666666667 # gamma = C_p/C_v
+first_order_flux_correct = true
+
+<parthenon/output0>
+file_type = hdf5
+dt = 0.01
+id = prim
+variables = prim
+
+<parthenon/output1>
+file_type = hst
+dt = 0.1

--- a/src/pgen/orszag_tang.cpp
+++ b/src/pgen/orszag_tang.cpp
@@ -45,7 +45,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         u(IM2, k, j, i) = -d0 * v0 * std::sin(2.0 * M_PI * coords.Xc<1>(i));
         u(IM3, k, j, i) = 0.0;
 
-        u(IB1, k, j, i) = -B0 * std::sin(2.0 * M_PI * coords.Xc<2>(j));
+        u(IB1, k, j, i) = B0 * std::sin(2.0 * M_PI * coords.Xc<2>(j));
         u(IB2, k, j, i) = B0 * std::sin(4.0 * M_PI * coords.Xc<1>(i));
         u(IB3, k, j, i) = 0.0;
 

--- a/src/pgen/orszag_tang.cpp
+++ b/src/pgen/orszag_tang.cpp
@@ -1,6 +1,7 @@
 
+//========================================================================================
 // AthenaPK - a performance portable block structured AMR MHD code
-// Copyright (c) 2021, Athena Parthenon Collaboration. All rights reserved.
+// Copyright (c) 2021-2023, Athena Parthenon Collaboration. All rights reserved.
 // Licensed under the 3-Clause License (the "LICENSE")
 //========================================================================================
 //! \file orszag_tang.cpp
@@ -41,6 +42,10 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
       "ProblemGenerator: Orszag-Tang", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
         u(IDN, k, j, i) = d0;
+        // Note the different signs in this pgen compared to the the eqn mentioned in the
+        // original paper (and other codes).
+        // They are related to our domain going from -0.5 to 0.5 (for symmetry reason)
+        // rather than 0  to 2pi (i.e., the sign for single wave sinus is flipped).
         u(IM1, k, j, i) = d0 * v0 * std::sin(2.0 * M_PI * coords.Xc<2>(j));
         u(IM2, k, j, i) = -d0 * v0 * std::sin(2.0 * M_PI * coords.Xc<1>(i));
         u(IM3, k, j, i) = 0.0;


### PR DESCRIPTION
There's seems to be a typo between https://www.astro.princeton.edu/~jstone/Athena/tests/orszag-tang/pagesource.html and what's implemented in the code (e.g, Athena++) based on the vector potential.
With the fixed init conditions the output at t=0.48 now looks like:

![image](https://github.com/parthenon-hpc-lab/athenapk/assets/22685568/6930d5d3-4aa2-4e4c-a4ea-726ec0e34326)
