### PR TITLE
WIP: print the cell that sets the CFL timestep

### DIFF
--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -640,8 +640,10 @@ Real EstimateHyperbolicTimestep(MeshData<Real> *md) {
         const Real B2 = prim(IB2, k, j, i);
         const Real B3 = prim(IB3, k, j, i);
 
-        Real lambda_max_x, lambda_max_y, lambda_max_z;
-        
+        Real lambda_max_x{};
+        Real lambda_max_y{};
+        Real lambda_max_z{};
+
         if constexpr (fluid == Fluid::euler) {
           lambda_max_x = eos.SoundSpeed(w);
           lambda_max_y = lambda_max_x;
@@ -674,11 +676,11 @@ Real EstimateHyperbolicTimestep(MeshData<Real> *md) {
       },
       Kokkos::Min<ValPropPair<Real, CellPrimValues>>(min_dt_hyperbolic));
 
-  // Now min_dt_hyperbolic.value contains the CFL timestep and min_dt_hyperbolic.index
-  // contains the primitive vars for the cell that set the timestep
+  // min_dt_hyperbolic.value now contains the CFL timestep and min_dt_hyperbolic.index
+  // contains the primitive vars for the cell that set the timestep.
 
   // TODO(bwibking): the cell properties still need to be propagated through the MPI
-  // reduction
+  // reduction.
 
   // TODO(pgrete) THIS WORKAROUND IS NOT THREAD SAFE (though this will only become
   // relevant once parthenon uses host-multithreading in the driver).

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -89,18 +89,9 @@ template <typename TV, typename TI>
 struct ValPropPair {
   TV value;
   TI index;
-
-  constexpr TV &first() { return value; }
-  constexpr TV const &first() const { return value; }
-  constexpr TI &second() { return index; }
-  constexpr TI const &second() const { return index; }
-
+  
   static constexpr ValPropPair<TV, TI> max() {
     return ValPropPair<TV, TI>{std::numeric_limits<TV>::max(), TI()};
-  }
-
-  static constexpr ValPropPair<TV, TI> min() {
-    return ValPropPair<TV, TI>{std::numeric_limits<TV>::min(), TI()};
   }
 
   friend constexpr bool operator<(ValPropPair<TV, TI> const &a,
@@ -120,7 +111,7 @@ namespace Kokkos { // reduction identity must be defined in Kokkos namespace
    template<typename TV, typename TI>
    struct reduction_identity<Hydro::ValPropPair<TV, TI>> {
       KOKKOS_FORCEINLINE_FUNCTION static Hydro::ValPropPair<TV, TI> min() {
-         return Hydro::ValPropPair<TV, TI>::min();
+         return Hydro::ValPropPair<TV, TI>::max(); // confusingly, this is correct
       }
    };
 }

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -74,6 +74,46 @@ constexpr size_t GetNVars<Fluid::glmmhd>() {
   return 9; // above plus B_x, B_y, B_z, psi
 }
 
+struct CellPrimValues {
+  Real rho{};
+  Real v1{};
+  Real v2{};
+  Real v3{};
+  Real P{};
+  Real B1{};
+  Real B2{};
+  Real B3{};
+};
+
+template <typename TV, typename TI>
+struct ValPropPair {
+  TV value;
+  TI index;
+
+  constexpr TV &first() { return value; }
+  constexpr TV const &first() const { return value; }
+  constexpr TI &second() { return index; }
+  constexpr TI const &second() const { return index; }
+
+  static constexpr ValPropPair<TV, TI> max() {
+    return ValPropPair<TV, TI>{std::numeric_limits<TV>::max(), TI()};
+  }
+
+  static constexpr ValPropPair<TV, TI> lowest() {
+    return ValPropPair<TV, TI>{std::numeric_limits<TV>::lowest(), TI()};
+  }
+
+  friend constexpr bool operator<(ValPropPair<TV, TI> const &a,
+                                  ValPropPair<TV, TI> const &b) {
+    return a.value < b.value;
+  }
+
+  friend constexpr bool operator>(ValPropPair<TV, TI> const &a,
+                                  ValPropPair<TV, TI> const &b) {
+    return a.value > b.value;
+  }
+};
+
 } // namespace Hydro
 
 #endif // HYDRO_HYDRO_HPP_

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -99,8 +99,8 @@ struct ValPropPair {
     return ValPropPair<TV, TI>{std::numeric_limits<TV>::max(), TI()};
   }
 
-  static constexpr ValPropPair<TV, TI> lowest() {
-    return ValPropPair<TV, TI>{std::numeric_limits<TV>::lowest(), TI()};
+  static constexpr ValPropPair<TV, TI> min() {
+    return ValPropPair<TV, TI>{std::numeric_limits<TV>::min(), TI()};
   }
 
   friend constexpr bool operator<(ValPropPair<TV, TI> const &a,

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -116,4 +116,13 @@ struct ValPropPair {
 
 } // namespace Hydro
 
+namespace Kokkos { // reduction identity must be defined in Kokkos namespace
+   template<typename TV, typename TI>
+   struct reduction_identity<Hydro::ValPropPair<TV, TI>> {
+      KOKKOS_FORCEINLINE_FUNCTION static Hydro::ValPropPair<TV, TI> min() {
+         return Hydro::ValPropPair<TV, TI>::min();
+      }
+   };
+}
+
 #endif // HYDRO_HYDRO_HPP_

--- a/src/hydro/hydro_driver.cpp
+++ b/src/hydro/hydro_driver.cpp
@@ -376,10 +376,15 @@ TaskCollection HydroDriver::MakeTaskCollection(BlockList_t &blocks, int stage) {
     auto &mu0 = pmesh->mesh_data.GetOrAdd("base", i);
     auto fill_derived =
         tl.AddTask(none, parthenon::Update::FillDerived<MeshData<Real>>, mu0.get());
+  }
 
+  TaskRegion &explicitly_sync_region = tc.AddRegion(1);
+  {
+    auto &tl = explicitly_sync_region[0];
+    auto &mu0 = pmesh->mesh_data.Get("base");
     if (stage == integrator->nstages) {
-      auto new_dt = tl.AddTask(
-          fill_derived, parthenon::Update::EstimateTimestep<MeshData<Real>>, mu0.get());
+      auto new_dt_task = tl.AddTask(
+          none, parthenon::Update::EstimateTimestep<MeshData<Real>>, mu0.get());
     }
   }
 


### PR DESCRIPTION
This modifies the timestep reduction to include the cell properties, so that we can print the properties/location of the cell that ends up setting the CFL timestep for hydro.