### PR TITLE
WIP: Velocity and temperature ceilings in EOS

### DIFF
--- a/src/eos/adiabatic_glmmhd.hpp
+++ b/src/eos/adiabatic_glmmhd.hpp
@@ -23,9 +23,11 @@ using parthenon::Real;
 
 class AdiabaticGLMMHDEOS : public EquationOfState {
  public:
-  AdiabaticGLMMHDEOS(Real pressure_floor, Real density_floor, Real internal_e_floor,
-                     Real gamma)
-      : EquationOfState(pressure_floor, density_floor, internal_e_floor), gamma_{gamma} {}
+   AdiabaticGLMMHDEOS(Real pressure_floor, Real density_floor,
+       Real internal_e_floor, Real velocity_ceiling, Real internal_e_ceiling,
+       Real gamma)
+     : EquationOfState(pressure_floor, density_floor, internal_e_floor,
+       velocity_ceiling, internal_e_ceiling), gamma_{gamma} {}
 
   void ConservedToPrimitive(MeshData<Real> *md) const override;
 
@@ -65,6 +67,9 @@ class AdiabaticGLMMHDEOS : public EquationOfState {
     auto density_floor_ = GetDensityFloor();
     auto pressure_floor_ = GetPressureFloor();
     auto e_floor_ = GetInternalEFloor();
+
+    auto velocity_ceiling_ = GetVelocityCeiling();
+    auto e_ceiling_ = GetInternalECeiling();
 
     Real &u_d = cons(IDN, k, j, i);
     Real &u_m1 = cons(IM1, k, j, i);
@@ -109,6 +114,23 @@ class AdiabaticGLMMHDEOS : public EquationOfState {
     Real e_B = 0.5 * (SQR(u_b1) + SQR(u_b2) + SQR(u_b3));
     w_p = gm1 * (u_e - e_k - e_B);
 
+    // apply velocity ceiling. By default ceiling is std::numeric_limits<Real>::infinity()
+    const Real w_v2 = SQR(w_vx) + SQR(w_vy) + SQR(w_vz);
+    if( w_v2 > SQR(velocity_ceiling_) ){
+      const Real w_v = sqrt(w_v2);
+      w_vx *= velocity_ceiling_/w_v;
+      w_vy *= velocity_ceiling_/w_v;
+      w_vz *= velocity_ceiling_/w_v;
+
+      u_m1 *= velocity_ceiling_/w_v;
+      u_m2 *= velocity_ceiling_/w_v;
+      u_m3 *= velocity_ceiling_/w_v;
+
+      Real e_k_new = 0.5 * u_d * SQR(velocity_ceiling_);
+      u_e -= e_k - e_k_new;
+      e_k = e_k_new;
+    }
+
     // Let's apply floors explicitly, i.e., by default floor will be disabled (<=0)
     // and the code will fail if a negative pressure is encountered.
     PARTHENON_REQUIRE(w_p > 0.0 || pressure_floor_ > 0.0 || e_floor_ > 0.0,
@@ -128,6 +150,14 @@ class AdiabaticGLMMHDEOS : public EquationOfState {
       // apply temperature floor, correct total energy
       u_e = (u_d * e_floor_) + e_k + e_B;
       w_p = eff_pressure_floor;
+    }
+
+    // temperature (internal energy) based pressure ceiling
+    const Real eff_pressure_ceiling = gm1 * u_d * e_ceiling_;
+    if (w_p > eff_pressure_ceiling) {
+      // apply temperature ceiling, correct total energy
+      u_e = (u_d * e_ceiling_) + e_k;
+      w_p = eff_pressure_ceiling;
     }
 
     // Convert passive scalars

--- a/src/eos/adiabatic_glmmhd.hpp
+++ b/src/eos/adiabatic_glmmhd.hpp
@@ -156,7 +156,7 @@ class AdiabaticGLMMHDEOS : public EquationOfState {
     const Real eff_pressure_ceiling = gm1 * u_d * e_ceiling_;
     if (w_p > eff_pressure_ceiling) {
       // apply temperature ceiling, correct total energy
-      u_e = (u_d * e_ceiling_) + e_k;
+      u_e = (u_d * e_ceiling_) + e_k + e_B;
       w_p = eff_pressure_ceiling;
     }
 

--- a/src/eos/eos.hpp
+++ b/src/eos/eos.hpp
@@ -32,9 +32,11 @@ using parthenon::Real;
 
 class EquationOfState {
  public:
-  EquationOfState(Real pressure_floor, Real density_floor, Real internal_e_floor)
-      : pressure_floor_(pressure_floor), density_floor_(density_floor),
-        internal_e_floor_(internal_e_floor) {}
+   EquationOfState(Real pressure_floor, Real density_floor, Real
+       internal_e_floor, Real velocity_ceiling, Real internal_e_ceiling)
+     : pressure_floor_(pressure_floor), density_floor_(density_floor),
+     internal_e_floor_(internal_e_floor), velocity_ceiling_(velocity_ceiling),
+     internal_e_ceiling_(internal_e_ceiling) {}
   virtual void ConservedToPrimitive(MeshData<Real> *md) const = 0;
 
   KOKKOS_INLINE_FUNCTION
@@ -47,8 +49,15 @@ class EquationOfState {
   KOKKOS_INLINE_FUNCTION
   Real GetInternalEFloor() const { return internal_e_floor_; }
 
+  KOKKOS_INLINE_FUNCTION
+  Real GetVelocityCeiling() const { return velocity_ceiling_; }
+
+  KOKKOS_INLINE_FUNCTION
+  Real GetInternalECeiling() const { return internal_e_ceiling_; }
+
  private:
   Real pressure_floor_, density_floor_, internal_e_floor_;
+  Real velocity_ceiling_, internal_e_ceiling_;
 };
 
 #endif // EOS_EOS_HPP_

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -487,12 +487,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     pkg->AddParam<>("conduction", conduction);
 
     if (fluid == Fluid::euler) {
-      AdiabaticHydroEOS eos(pfloor, dfloor, efloor, gamma, vceil, eceil);
+      AdiabaticHydroEOS eos(pfloor, dfloor, efloor, vceil, eceil, gamma);
       pkg->AddParam<>("eos", eos);
       pkg->FillDerivedMesh = ConsToPrim<AdiabaticHydroEOS>;
       pkg->EstimateTimestepMesh = EstimateTimestep<Fluid::euler>;
     } else if (fluid == Fluid::glmmhd) {
-      AdiabaticGLMMHDEOS eos(pfloor, dfloor, efloor, gamma, vceil, eceil);
+      AdiabaticGLMMHDEOS eos(pfloor, dfloor, efloor, vceil, eceil, gamma);
       pkg->AddParam<>("eos", eos);
       pkg->FillDerivedMesh = ConsToPrim<AdiabaticGLMMHDEOS>;
       pkg->EstimateTimestepMesh = EstimateTimestep<Fluid::glmmhd>;

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -439,6 +439,21 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       efloor = Tfloor / mbar_over_kb / (gamma - 1.0);
     }
 
+    // By default disable ceilings by setting to infinity
+    Real vceil = pin->GetOrAddReal("hydro", "vceil", std::numeric_limits<Real>::infinity());
+    Real Tceil = pin->GetOrAddReal("hydro", "Tceil", std::numeric_limits<Real>::infinity());
+    Real eceil = Tceil;
+    if (eceil < std::numeric_limits<Real>::infinity()) {
+      if (!pkg->AllParams().hasKey("mbar_over_kb")) {
+        PARTHENON_FAIL("Temperature ceiling requires units and gas composition. "
+                       "Either set a 'units' block and the 'hydro/He_mass_fraction' in "
+                       "input file or use a pressure floor "
+                       "(defined code units) instead.");
+      }
+      auto mbar_over_kb = pkg->Param<Real>("mbar_over_kb");
+      eceil = Tceil / mbar_over_kb / (gamma - 1.0);
+    }
+
     auto conduction = Conduction::none;
     auto conduction_str = pin->GetOrAddString("diffusion", "conduction", "none");
     if (conduction_str == "spitzer") {
@@ -472,12 +487,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     pkg->AddParam<>("conduction", conduction);
 
     if (fluid == Fluid::euler) {
-      AdiabaticHydroEOS eos(pfloor, dfloor, efloor, gamma);
+      AdiabaticHydroEOS eos(pfloor, dfloor, efloor, gamma, vceil, eceil);
       pkg->AddParam<>("eos", eos);
       pkg->FillDerivedMesh = ConsToPrim<AdiabaticHydroEOS>;
       pkg->EstimateTimestepMesh = EstimateTimestep<Fluid::euler>;
     } else if (fluid == Fluid::glmmhd) {
-      AdiabaticGLMMHDEOS eos(pfloor, dfloor, efloor, gamma);
+      AdiabaticGLMMHDEOS eos(pfloor, dfloor, efloor, gamma, vceil, eceil);
       pkg->AddParam<>("eos", eos);
       pkg->FillDerivedMesh = ConsToPrim<AdiabaticGLMMHDEOS>;
       pkg->EstimateTimestepMesh = EstimateTimestep<Fluid::glmmhd>;


### PR DESCRIPTION
Adds a velocity and temperature ceiling to the EOS functions like we apply density and pressure floors. This is a hack to correct the issue where a portion of the domain reaches relativistic velocities.

Sibling PR to #75 