### PR TITLE
Workaround for CUDA <=11.6 in first order flux corrections

### DIFF
--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -961,8 +961,9 @@ TaskStatus CalculateFluxes(std::shared_ptr<MeshData<Real>> &md) {
 // (multiple calls) versus extra memory usage is.
 template <Fluid fluid>
 TaskStatus FirstOrderFluxCorrect(MeshData<Real> *u0_data, MeshData<Real> *u1_data,
-                                 const Real gam0_, const Real gam1_, const Real beta_dt_) {
-  //Work around for CUDA <=11.6
+                                 const Real gam0_, const Real gam1_,
+                                 const Real beta_dt_) {
+  // Work around for CUDA <=11.6
   const Real gam0 = gam0_;
   const Real gam1 = gam1_;
   const Real beta_dt = beta_dt_;

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -961,7 +961,12 @@ TaskStatus CalculateFluxes(std::shared_ptr<MeshData<Real>> &md) {
 // (multiple calls) versus extra memory usage is.
 template <Fluid fluid>
 TaskStatus FirstOrderFluxCorrect(MeshData<Real> *u0_data, MeshData<Real> *u1_data,
-                                 const Real gam0, const Real gam1, const Real beta_dt) {
+                                 const Real gam0_, const Real gam1_, const Real beta_dt_) {
+  //Work around for CUDA <=11.6
+  const Real gam0 = gam0_;
+  const Real gam1 = gam1_;
+  const Real beta_dt = beta_dt_;
+
   auto pmb = u0_data->GetBlockData(0)->GetBlockPointer();
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);


### PR DESCRIPTION
Quick workaround of an `nvcc` bug in the first order flux corrections to get them running with Cuda <=11.6. Necessary for Chicoma since GPUDirect isn't compatible with the CUDA >=11.7.