### PR TITLE
Hotfix magic number for magnetic tower donut

### DIFF
--- a/src/pgen/cluster/magnetic_tower.hpp
+++ b/src/pgen/cluster/magnetic_tower.hpp
@@ -67,7 +67,7 @@ class MagneticTowerObj {
       // Compute the potential in jet cylindrical coordinates
       a_r = 0.0;
       a_theta = 0.0;
-      if (fabs(h) >= 0.001 && fabs(h) <= offset_ + thickness_) {
+      if (fabs(h) >= offset_ && fabs(h) <= offset_ + thickness_) {
         a_h = field_ * l_scale_ * exp_r2_h2;
       } else {
         a_h = 0.0;
@@ -110,7 +110,7 @@ class MagneticTowerObj {
       const parthenon::Real exp_r2_h2 = exp(-pow(r / l_scale_, 2));
       // Compute the field in jet cylindrical coordinates
       b_r = 0.0;
-      if (fabs(h) >= 0.001 && fabs(h) <= offset_ + thickness_) {
+      if (fabs(h) >= offset_ && fabs(h) <= offset_ + thickness_) {
         b_theta = 2.0 * field_ * r / l_scale_ * exp_r2_h2;
       } else {
         b_theta = 0.0;


### PR DESCRIPTION
Looks like there was a hardcoded minimal offset for the donut leftover from original development.
Does not affect our INCITE runs as we ran with an offset of 0.001.

Thanks @mfournier01 for reporting (this came up when the `MagneticTowerModel::PowerSrcTerm mt_linear_contrib and mt_quadratic_contrib are both zero. (Has MagneticTowerReducePowerContribs been called?)` safetey check was triggered for offset <0.001).