### PR TITLE
Hydrodynamic Cluster Fixes

### DIFF
--- a/src/pgen/cluster/agn_feedback.cpp
+++ b/src/pgen/cluster/agn_feedback.cpp
@@ -361,8 +361,8 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
             ///////////////////////////////////////////////////////////////////
 
             eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
-            const Real old_specific_internal_e =
-                prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
+            //const Real old_specific_internal_e =
+            //    prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
 
             cons(IDN, k, j, i) += jet_density;
             cons(IM1, k, j, i) += jet_momentum * sign_jet * jet_axis_x;
@@ -379,12 +379,13 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
             }
 
             eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
-            const Real new_specific_internal_e =
-                prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
-            PARTHENON_REQUIRE(
-                new_specific_internal_e > jet_specific_internal_e ||
-                    new_specific_internal_e > old_specific_internal_e,
-                "Kinetic injection leads to temperature below jet and existing gas");
+            //We're 
+            //const Real new_specific_internal_e =
+            //    prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
+            //PARTHENON_REQUIRE(
+            //    new_specific_internal_e > jet_specific_internal_e ||
+            //        new_specific_internal_e > old_specific_internal_e,
+            //    "Kinetic injection leads to temperature below jet and existing gas");
           }
 
           // Apply velocity ceiling

--- a/src/pgen/cluster/agn_feedback.cpp
+++ b/src/pgen/cluster/agn_feedback.cpp
@@ -361,8 +361,6 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
             ///////////////////////////////////////////////////////////////////
 
             eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
-            // const Real old_specific_internal_e =
-            //    prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
 
             cons(IDN, k, j, i) += jet_density;
             cons(IM1, k, j, i) += jet_momentum * sign_jet * jet_axis_x;
@@ -379,13 +377,6 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
             }
 
             eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
-            // We're
-            // const Real new_specific_internal_e =
-            //    prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
-            // PARTHENON_REQUIRE(
-            //    new_specific_internal_e > jet_specific_internal_e ||
-            //        new_specific_internal_e > old_specific_internal_e,
-            //    "Kinetic injection leads to temperature below jet and existing gas");
           }
 
           // Apply velocity ceiling

--- a/src/pgen/cluster/agn_feedback.cpp
+++ b/src/pgen/cluster/agn_feedback.cpp
@@ -361,7 +361,7 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
             ///////////////////////////////////////////////////////////////////
 
             eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
-            //const Real old_specific_internal_e =
+            // const Real old_specific_internal_e =
             //    prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
 
             cons(IDN, k, j, i) += jet_density;
@@ -379,10 +379,10 @@ void AGNFeedback::FeedbackSrcTerm(parthenon::MeshData<parthenon::Real> *md,
             }
 
             eos.ConsToPrim(cons, prim, nhydro, nscalars, k, j, i);
-            //We're 
-            //const Real new_specific_internal_e =
+            // We're
+            // const Real new_specific_internal_e =
             //    prim(IPR, k, j, i) / (prim(IDN, k, j, i) * (eos.GetGamma() - 1.));
-            //PARTHENON_REQUIRE(
+            // PARTHENON_REQUIRE(
             //    new_specific_internal_e > jet_specific_internal_e ||
             //        new_specific_internal_e > old_specific_internal_e,
             //    "Kinetic injection leads to temperature below jet and existing gas");

--- a/src/pgen/cluster/cluster_clips.cpp
+++ b/src/pgen/cluster/cluster_clips.cpp
@@ -70,6 +70,7 @@ void ApplyClusterClips(MeshData<Real> *md, const parthenon::SimTime &tm,
     const Real vAceil2 = SQR(vAceil);
     const Real gm1 = (hydro_pkg->Param<Real>("AdiabaticIndex") - 1.0);
 
+    const bool magnetic_fields = (hydro_pkg->Param<Fluid>("fluid") == Fluid::glmmhd);
     Real added_dfloor_mass = 0.0, removed_vceil_energy = 0.0, added_vAceil_mass = 0.0,
          removed_eceil_energy = 0.0;
 
@@ -123,7 +124,7 @@ void ApplyClusterClips(MeshData<Real> *md, const parthenon::SimTime &tm,
               }
             }
 
-            if (vAceil2 < std::numeric_limits<Real>::infinity()) {
+            if (magnetic_fields && vAceil2 < std::numeric_limits<Real>::infinity()) {
               // Apply Alfven velocity ceiling by raising density
               const Real rho = prim(IDN, k, j, i);
               const Real B2 = (SQR(prim(IB1, k, j, i)) + SQR(prim(IB2, k, j, i)) +


### PR DESCRIPTION
Removes checking for Alfvenic velocity ceiling for hydrodynamic cluster runs, fixing hydro runs.

Also removes the check that internal energy increases with the addition of kinetic energy, which check broke some INCITE runs.