### PR TITLE
update parthenon to 314ac5c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed (not changing behavior/API/variables/...)
 
 ### Infrastructure
+- [[PR 105]](https://github.com/parthenon-hpc-lab/athenapk/pull/105) Bump Parthenon to latest develop (2024-03-13)
 - [[PR 84]](https://github.com/parthenon-hpc-lab/athenapk/pull/84) Added `CHANGELOG.md`
 
 ### Removed (removing behavior/API/varaibles/...)


### PR DESCRIPTION
This enables verbose output when the CI tests fail.

Closes https://github.com/parthenon-hpc-lab/athenapk/issues/104.