### PR TITLE
[WIP] delete FewModesFT copy constructor

### DIFF
--- a/src/utils/few_modes_ft.hpp
+++ b/src/utils/few_modes_ft.hpp
@@ -47,6 +47,10 @@ class FewModesFT {
              std::string prefix, int num_modes, ParArray2D<Real> k_vec, Real k_peak,
              Real sol_weight, Real t_corr, uint32_t rseed, bool fill_ghosts = false);
 
+  // prevent objects from being copied (this prevents user error)
+  FewModesFT(FewModesFT const &) = delete;
+  FewModesFT &operator=(FewModesFT const &) = delete;
+
   ParArray2D<Complex> GetVarHat() { return var_hat_; }
   int GetNumModes() { return num_modes_; }
   void SetPhases(MeshBlock *pmb, ParameterInput *pin);


### PR DESCRIPTION
This deletes the copy constructor and copy assignment operator for `FewModesFT` in order to avoid user error.

Users should not need to copy this object.  If a copy is needed, an explicit `.copy()` method can be added to this class.