### PR TITLE
AGN triggering_inflow rate

### DIFF
--- a/src/pgen/cluster/agn_triggering.hpp
+++ b/src/pgen/cluster/agn_triggering.hpp
@@ -15,7 +15,7 @@
 #include <mesh/mesh.hpp>
 #include <parameter_input.hpp>
 #include <parthenon/package.hpp>
-
+#include <string> 
 // AthenaPK headers
 #include "../../units.hpp"
 #include "jet_coords.hpp"
@@ -34,9 +34,12 @@ class AGNTriggering {
  private:
   const parthenon::Real gamma_;
   parthenon::Real mean_molecular_mass_;
-
+  
  public:
   const AGNTriggeringMode triggering_mode_;
+ 
+  parthenon::Real inflow_cold_=0.0;         // Cold mass inflow rate
+  parthenon::Real inflow_tot_=0.0;          // Total gas mass inflow rate
 
   const parthenon::Real accretion_radius_;
 
@@ -71,9 +74,9 @@ class AGNTriggering {
   // Compute Cold gas accretion rate within the accretion radius for cold gas triggering
   // and simultaneously remove cold gas (updating conserveds and primitives)
   template <typename EOS>
-  void ReduceColdMass(parthenon::Real &cold_mass,
+  void ReduceColdMass(parthenon::Real &cold_mass,parthenon::Real &total_mass,
                       parthenon::MeshData<parthenon::Real> *md, const parthenon::Real dt,
-                      const EOS eos) const;
+                      const EOS eos) ;
 
   // Compute Mass-weighted total density, velocity, and sound speed and total mass
   // for Bondi accretion


### PR DESCRIPTION
The objective is compute the inflow rate for total gas mass (total mass[i]-total mass[i-1])/(time[i]-time[i-1]) and inflow rate cold for only cold mass (cold mass[i]-cold mass[i-1])/(time[i]-time[i-1]) and output the values in agn_triggering.dat together accretion rate and others. When I compile the code I got some errors about initializing variables and their call/update, because some parameters are constant also if I remove 'const' definition.


```

/home/elyon/athenapk/src/pgen/cluster/agn_triggering.cpp(432): error: no instance of function template "cluster::AGNTriggering::ReduceColdMass" matches the argument list and object (the object has type qualifiers that prevent a match)
            argument types are: (parthenon::Real, parthenon::Real, parthenon::MeshData<parthenon::Real> *, const parthenon::Real, const AdiabaticHydroEOS)
            object type is: const cluster::AGNTriggering
        agn_triggering.ReduceColdMass(cold_mass, total_mass,md, dt,
                       ^

/home/elyon/athenapk/src/pgen/cluster/agn_triggering.cpp(435): error: no instance of function template "cluster::AGNTriggering::ReduceColdMass" matches the argument list and object (the object has type qualifiers that prevent a match)
            argument types are: (parthenon::Real, parthenon::Real, parthenon::MeshData<parthenon::Real> *, const parthenon::Real, const AdiabaticGLMMHDEOS)
            object type is: const cluster::AGNTriggering
        agn_triggering.ReduceColdMass(cold_mass, total_mass,md, dt,
                       ^

/home/elyon/athenapk/src/pgen/cluster/agn_triggering.cpp(539): error: expression must be a modifiable lvalue
      agn_triggering.inflow_cold_ = (cold_mass - hydro_pkg->Param<Real>("agn_triggering_prev_cold_mass")) / tm.dt;
      ^

/home/elyon/athenapk/src/pgen/cluster/agn_triggering.cpp(540): error: expression must be a modifiable lvalue
      agn_triggering.inflow_tot_ = (total_mass - hydro_pkg->Param<Real>("agn_triggering_prev_total_mass")) / tm.dt;
      ^

```
