### PR TITLE
Fix inconsistent mindx (-> c_h) for multilevel MHD simulations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
           # Pick GPU with most available memory
           export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=memory.free,index --format=csv,nounits,noheader | sort -nr | head -1 | awk '{ print $NF }')
           ctest -L ${{ matrix.parallel }} --timeout 3600
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: regression-output
+          name: regression-output-${{ matrix.parallel }}
           path: |
             build/CMakeFiles/CMakeOutput.log
             build/CMakeFiles/CMakeOutput.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Current develop (i.e., `main` branch)
 
+### IMPORTANT
+
+If you pulled from `main` after 11 Nov 24 ([[PR 124]](https://github.com/parthenon-hpc-lab/athenapk/pull/124))
+please updated immediate to a version after 18 Mar 24 ([[PR 136]](https://github.com/parthenon-hpc-lab/athenapk/pull/136)).
+In between a subtle bug was introduced that resulted in inconsistent divergence cleaning speeds in MHD simulation with mesh
+refinement.
+
 ### Added (new features/APIs/variables/...)
 - [[PR 89]](https://github.com/parthenon-hpc-lab/athenapk/pull/89) Add viscosity and resistivity
 - [[PR 1]](https://github.com/parthenon-hpc-lab/athenapk/pull/1) Add isotropic thermal conduction and RKL2 supertimestepping
@@ -13,10 +20,12 @@
 - [[PR 84]](https://github.com/parthenon-hpc-lab/athenapk/pull/84) Bump Parthenon to latest develop (2024-02-15)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 136]](https://github.com/parthenon-hpc-lab/athenapk/pull/136) Fix using MPI reduced mindx
 - [[PR 128]](https://github.com/parthenon-hpc-lab/athenapk/pull/128) Fixed `dt_diff` in RKL2
 
 ### Infrastructure
-- [[PR 128]](https://github.com/parthenon-hpc-lab/athenapk/pull/128) Bump Parthenon to support `dn` based outputs
+- [[PR 136]](https://github.com/parthenon-hpc-lab/athenapk/pull/136) Bump Kokkos 4.5.1 (for support of AMD APUs)
+- [[PR 129]](https://github.com/parthenon-hpc-lab/athenapk/pull/129) Bump Parthenon to support `dn` based outputs
 - [[PR 124]](https://github.com/parthenon-hpc-lab/athenapk/pull/124) Bump Kokkos 4.4.1 (and Parthenon to include view-of-view fix)
 - [[PR 117]](https://github.com/parthenon-hpc-lab/athenapk/pull/117) Update devcontainer.json to latest CI container
 - [[PR 114]](https://github.com/parthenon-hpc-lab/athenapk/pull/114) Bump Parthenon 24.08 and Kokkos to 4.4.00

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -135,6 +135,7 @@ void PreStepMeshUserWorkInLoop(Mesh *pmesh, ParameterInput *pin, SimTime &tm) {
     // Finally update c_h
     const auto &cfl_hyp = hydro_pkg->Param<Real>("cfl");
     const auto &dt_hyp = hydro_pkg->Param<Real>("dt_hyp");
+    mindx = hydro_pkg->Param<Real>("mindx");
     hydro_pkg->UpdateParam("c_h", cfl_hyp * mindx / dt_hyp);
   }
 }


### PR DESCRIPTION
Fixes #135 

`mindx` was reduced across ranks, but the reduced value was not used in the following c_h calculation resulting in inconsistent `c_h` depending on the distribution of blocks.
A reproducer input (can be run on a laptop) is below and I'll create a regression test for this in the very near future.

Also bumps Kokkos to 4.5.1 (to support AMD APUs).

Reproducer:

- works fine on 1, 2, and 4 ranks but crashes after 3 cycles on 8 or 16 ranks,

```
# AthenaPK - a performance portable block structured AMR MHD code
# Copyright (c) 2020, Athena Parthenon Collaboration. All rights reserved.
# Licensed under the BSD 3-Clause License (the "LICENSE");

<comment>
problem = 3D Hydro linear wave convergence

<job>
problem_id = linear_wave_mhd

<problem/linear_wave>
compute_error = true  # when 'true' outputs L1 error compared to initial data
wave_flag = 0         # Wave family number (0 - 4 for adiabatic hydro)
amp       = 1.0e-6    # Wave Amplitude
vflow     = 0.0       # background flow velocity
test      = true

<parthenon/mesh>
refinement  = static
nghost = 2

nx1        = 64        # Number of zones in X1-direction
x1min      =-0.2     # minimum value of X1
x1max      = 0.2     # maximum value of X1
ix1_bc     = periodic        # inner-X1 boundary flag
ox1_bc     = periodic        # outer-X1 boundary flag

nx2        = 64        # Number of zones in X2-direction
x2min      =-0.2     # minimum value of X2
x2max      = 0.2     # maximum value of X2
ix2_bc     = periodic        # inner-X2 boundary flag
ox2_bc     = periodic        # outer-X2 boundary flag

nx3        = 64        # Number of zones in X3-direction
x3min      =-0.2     # minimum value of X3
x3max      = 0.2     # maximum value of X3
ix3_bc     = periodic        # inner-X3 boundary flag
ox3_bc     = periodic        # outer-X3 boundary flag

<parthenon/meshblock>
nx1        = 16        # Number of zones in X1-direction
nx2        = 16        # Number of zones in X2-direction
nx3        = 16        # Number of zones in X3-direction

<parthenon/static_refinement6>
x1min = -0.01 
x1max =  0.01
x2min = -0.01
x2max =  0.01
x3min = -0.01
x3max =  0.01
level =  4


<parthenon/time>
integrator = rk2
cfl = 0.3
tlim = 1.0
nlim = 3
perf_cycle_offset = 2 # number of inital cycles not to be included in perf calc

<hydro>
fluid = glmmhd
eos = adiabatic
riemann = hlld
reconstruction = plm
gamma = 1.666666666666667 # gamma = C_p/C_v
scratch_level = 0 # 0 is actual scratch (tiny); 1 is HBM

<parthenon/output0>
file_type = rst
dt = 0.01
variables = cons
```