### PR TITLE
Add fstream header for compilation with nvhpc

### DIFF
--- a/src/pgen/turbulence.cpp
+++ b/src/pgen/turbulence.cpp
@@ -11,6 +11,7 @@
 #include <algorithm> // min, max
 #include <cmath>     // log
 #include <cstring>   // strcmp()
+#include <fstream>   // ofstream
 
 // Parthenon headers
 #include "basic_types.hpp"


### PR DESCRIPTION
Quick fix to eliminate this error on an NVHPC stack using g++ as the host compiler. I don't know why it occurs with this stack but the fix is quick and obvious.
```
267.1 FAILED: src/CMakeFiles/athenaPK.dir/pgen/turbulence.cpp.o
267.1 /project/athenapk/external/Kokkos/bin/nvcc_wrapper -DKOKKOS_DEPENDENCE -I/project/athenapk/external/parthenon/src -I/project/athenapk/build/parthenon/src/generated -I/project/athenapk/build/parthenon/Kokkos -I/project/athenapk/build/parthenon/Kokkos/core/src -I/project/athenapk/external/Kokkos/core/src -I/project/athenapk/external/Kokkos/tpls/desul/include -I/project/athenapk/external/Kokkos/tpls/mdspan/include -I/project/athenapk/build/parthenon/Kokkos/containers/src -I/project/athenapk/external/Kokkos/containers/src -I/project/athenapk/build/parthenon/Kokkos/algorithms/src -I/project/athenapk/external/Kokkos/algorithms/src -I/project/athenapk/build/parthenon/Kokkos/simd/src -I/project/athenapk/external/Kokkos/simd/src -isystem /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/hpcx/hpcx-2.22.1/ompi/include -isystem /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/hpcx/hpcx-2.22.1/ompi/include/openmpi -isystem /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/hpcx/hpcx-2.22.1/ompi/include/openmpi/opal/mca/hwloc/hwloc201/hwloc/include -isystem /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/hpcx/hpcx-2.22.1/ompi/include/openmpi/opal/mca/event/libevent2022/libevent -isystem /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/hpcx/hpcx-2.22.1/ompi/include/openmpi/opal/mca/event/libevent2022/libevent/include -O2 -g -DNDEBUG --expt-relaxed-constexpr -pthread -extended-lambda -Wext-lambda-captures-this -arch=sm_90 -MD -MT src/CMakeFiles/athenaPK.dir/pgen/turbulence.cpp.o -MF src/CMakeFiles/athenaPK.dir/pgen/turbulence.cpp.o.d -o src/CMakeFiles/athenaPK.dir/pgen/turbulence.cpp.o -c /project/athenapk/src/pgen/turbulence.cpp
267.1 /project/athenapk/src/pgen/turbulence.cpp(610): error: incomplete type "std::ofstream" is not allowed
267.1       std::ofstream outfile;
267.1                     ^
267.1
267.1 /project/athenapk/src/pgen/turbulence.cpp(614): error: incomplete type "std::basic_ofstream<char, std::char_traits<char>>" is not allowed
267.1         outfile.open(fname, std::ofstream::out);
267.1                             ^
267.1
267.1 /project/athenapk/src/pgen/turbulence.cpp(623): error: incomplete type "std::basic_ofstream<char, std::char_traits<char>>" is not allowed
267.1         outfile.open(fname, std::ofstream::out | std::ofstream::app);
267.1                             ^
267.1
267.1 /project/athenapk/src/pgen/turbulence.cpp(623): error: incomplete type "std::basic_ofstream<char, std::char_traits<char>>" is not allowed
267.1         outfile.open(fname, std::ofstream::out | std::ofstream::app);
267.1                                                  ^
267.1
```