### PR TITLE
Document agentic coding guidelines and add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--Provide a general summary of your changes in the title above, for
+example "Add AMR unit test for cell centered fields.".  Please avoid
+non-descriptive titles such as "Addresses issue #8576".-->
+
+## PR Summary
+
+<!--Please provide at least 1-2 sentences describing the pull request in
+detail.  Why is this change required?  What problem does it solve?-->
+
+<!--If it fixes an open issue, please link to the issue here.-->
+
+## PR Checklist
+
+<!-- Note that some of these check boxes may not apply to all pull requests -->
+
+- [ ] Code passes cpplint
+- [ ] New features are documented.
+- [ ] Adds a test for any bugs fixed. Adds tests for new features.
+- [ ] Code is formatted
+- [ ] Changes are summarized in CHANGELOG.md
+- [ ] Change is breaking (API, behavior, ...)
+  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
+  - [ ] PR is marked as breaking
+  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
+- [ ] Docs build
+- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/athenapk/blob/main/CONTRIBUTING.md#use-of-agentic-coding)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed (not changing behavior/API/variables/...)
 
 ### Infrastructure
+- [[PR 168]](https://github.com/parthenon-hpc-lab/athenapk/pull/168) Document agentic coding guidelines (and add PR template)
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ and revision any time as necessary.
     - [Contributing code](#contributing-code)
     - [Merging code](#merging-code)
         * [Merging code from a fork](#merging-code-from-a-fork)
+    - [Use of agentic coding](#use-of-agentic-coding)
     - [Formatting code](#formatting-code)
 
 ## User/community interaction and getting help
@@ -118,6 +119,25 @@ $ git push --set-upstream origin CONTRIBUTOR/feature-A
 ```
 
 NOTE: Any subsequent updates made to the forked branch will need to be manually pulled into the local branch.
+
+### Use of Agentic Coding
+
+The following general guidelines follow the current Parthenon guidelines, which
+were discussed in March 2026 during a
+[regular call](https://github.com/parthenon-hpc-lab/parthenon/wiki/2026.03.26-Meeting-Notes#handling-llm-supportedassisted-prs).
+They are subject to live evaluation and may change in the future.
+
+In general, there are no limitations to the use of agentic coding/LLMs/... given that
+- the usage is disclosed
+  - by adding `// This file was made in part with generative AI` to the file, and
+  - by clearly stating the extent of usage in the PR description
+- the person submitting the PR keeps ownership/responsiblity of all changes (i.e., conducts a thorough review themself)
+
+In addition, the following recommendations should be followed
+- for large/feature-style PRs a `plan.md` document outlining the changes should be part of the PR. The file should be named by the PR number and placed in the `docs/plan_histories` folder.
+  - if possible, large feature-style PRs are split into smaller, logically separated chunks (to ease reviewing)
+- condense/consolidate generated code (to ease maintenance) as it is (still) often much more verbose than necessary (and typical in the existing codebase)
+- reviewers are expected to be much more skeptical and thorough compared to code written by long-term contributors, and possibly more willing to reject
 
 ### Formatting code
 We use `clang-format` to automatically format the C++ code. If you have clang-format installed


### PR DESCRIPTION
Follows the current Parthenon guidelines, see https://github.com/parthenon-hpc-lab/parthenon/pull/1384, which are also conceptually in line, for example, with current linux kernel guidelines, see https://www.tomshardware.com/software/linux/linux-lays-down-the-law-on-ai-generated-code-yes-to-copilot-no-to-ai-slop-and-humans-take-the-fall-for-mistakes-after-months-of-fierce-debate-torvalds-and-maintainers-come-to-an-agreement