### PR TITLE
Make single-prec compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please update immediately or rebuild AthenaPK with `PARTHENON_DISABLE_SPARSE=OFF
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 188]](https://github.com/parthenon-hpc-lab/athenapk/pull/188) Fix compilation in single precision
 - [[PR 172]](https://github.com/parthenon-hpc-lab/athenapk/pull/172) Fixed data race condition in few modes IFT (no practical implication)
 
 ### Infrastructure

--- a/src/pgen/cluster/hydrostatic_equilibrium_sphere.cpp
+++ b/src/pgen/cluster/hydrostatic_equilibrium_sphere.cpp
@@ -168,7 +168,7 @@ HydrostaticEquilibriumSphere<GravitationalField, EntropyProfile>::generate_P_rho
   }
 
   // Add some room for R_start and R_end
-  r_start = std::max(0.0, r_start - r_sampling_ * dr);
+  r_start = Kokkos::max(static_cast<Real>(0.0), r_start - r_sampling_ * dr);
   r_end += r_sampling_ * dr;
 
   // Compute number of cells needed

--- a/src/recon/limo3_simple.hpp
+++ b/src/recon/limo3_simple.hpp
@@ -37,8 +37,11 @@ KOKKOS_INLINE_FUNCTION Real limo3_limiter(const Real dvp, const Real dvm, const 
   const Real q = (2.0 + theta) / 3.0;
 
   // (3.13) in CT09
-  const Real phi = std::max(
-      0.0, std::min(q, std::max(-0.5 * theta, std::min(2.0 * theta, std::min(q, 1.6)))));
+  const Real phi = Kokkos::max(
+      static_cast<Real>(0.0),
+      Kokkos::min(q, Kokkos::max(static_cast<Real>(-0.5) * theta,
+                                 Kokkos::min(static_cast<Real>(2.0) * theta,
+                                             Kokkos::min(q, static_cast<Real>(1.6))))));
 
   // (3.17) in CT09; indicator for asymp. region
   Real eta = r * dx;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Updated Partheon submodule to include https://github.com/parthenon-hpc-lab/parthenon/pull/1412 so that the code compiles with `Real=float`.
However, most pieces are still untested in single precision and more work is likely required, see https://github.com/parthenon-hpc-lab/parthenon/issues/1409

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/athenapk/blob/main/CONTRIBUTING.md#use-of-agentic-coding)
